### PR TITLE
[prisma][node.js][react] User can now see stitches on home screen: press to edit them and delete. Stitch image is the topmost song's image and user can rename them in editable text box.

### DIFF
--- a/back-end/prisma/migrations/20240711190854_added_image_url_for_cover_art/migration.sql
+++ b/back-end/prisma/migrations/20240711190854_added_image_url_for_cover_art/migration.sql
@@ -1,0 +1,8 @@
+/*
+  Warnings:
+
+  - Added the required column `imageUrl` to the `Stitch` table without a default value. This is not possible if the table is not empty.
+
+*/
+-- AlterTable
+ALTER TABLE "Stitch" ADD COLUMN     "imageUrl" TEXT NOT NULL;

--- a/back-end/prisma/schema.prisma
+++ b/back-end/prisma/schema.prisma
@@ -33,6 +33,7 @@ model Stitch {
   id          Int  @id @default(autoincrement())
   title       String
   duration    Int
+  imageUrl    String
   songs       Song[]
   mood        Float
   dance       Float

--- a/back-end/routes/songRoutes.js
+++ b/back-end/routes/songRoutes.js
@@ -12,7 +12,13 @@ router.get('/:stitchId', async (req, res) => {
             where: {
                 id: stitchId
             },
-            include: { songs: true }
+            include: {
+                songs: {
+                    orderBy: {
+                        id: 'asc'
+                    }
+                }
+            }
         })
         res.status(200).json(stitch.songs)
     }

--- a/front-end/src/Create.jsx
+++ b/front-end/src/Create.jsx
@@ -1,12 +1,14 @@
-import { useParams, useLocation } from 'react-router-dom';
+import { useParams, useLocation, useNavigate } from 'react-router-dom';
 import { useState, useEffect } from 'react';
-import { Box, Input, FormControl, Heading } from '@chakra-ui/react';
+import { Box, Input, FormControl, Heading, Button, Text } from '@chakra-ui/react';
 import Navbar from './Navbar';
 import Song from './Song';
+import CustomName from './CustomName';
 
 function Create() {
     const params = useParams();
     const location = useLocation();
+    const navigate = useNavigate();
     const username = params.username;
     const [searchOptions, setSearchOptions] = useState([]);
     const [currentStitchSongs, setCurrentStitchSongs] = useState([]);
@@ -37,7 +39,7 @@ function Create() {
             const searchData = await response.json();
             setSearchOptions(searchData.tracks.items);
         } catch (error) {
-            console.log(error);
+            console.error(error);
         }
     };
 
@@ -47,6 +49,20 @@ function Create() {
             currentAudio.currentTime = 0;
         }
         setCurrentAudio(audioElement);
+    };
+
+    const updateImage = async (imageUrl) => {
+        try {
+            const response = await fetch(`${import.meta.env.VITE_BACKEND_ADDRESS}/stitch/image`, {
+                method: 'PATCH',
+                headers: {
+                    'Content-Type': 'application/json'
+                },
+                body: JSON.stringify({ stitchId, imageUrl })
+            });
+        } catch (error) {
+            console.error('Error updating stitch:', error);
+        }
     };
 
     const handleAdd = (track) => {
@@ -71,7 +87,6 @@ function Create() {
             })
                 .then(response => response.json())
                 .then(data => {
-                    console.log('Song added:', data);
                     getStitchSongs();
                 })
                 .catch(error => {
@@ -86,6 +101,10 @@ function Create() {
         try {
             const response = await fetch(`${import.meta.env.VITE_BACKEND_ADDRESS}/song/${stitchId}`);
             const stitchSongs = await response.json();
+            if (stitchSongs.length != 0) {
+                const topSongImage = stitchSongs[0].album.images[0].url
+                updateImage(topSongImage)
+            }
             setCurrentStitchSongs(stitchSongs);
         } catch (error) {
             console.error('Error getting songs in stitch:', error);
@@ -95,6 +114,10 @@ function Create() {
 
     const handleRemove = (songId) => {
         setDeleteId(songId);
+    };
+
+    const finalizeStitch = () => {
+        navigate(`/${username}`);
     };
 
     useEffect(() => {
@@ -114,7 +137,7 @@ function Create() {
         } else {
             getStitchSongs();
         }
-    }, [deleteId, stitchId]); 
+    }, [deleteId, stitchId]);
 
     return (
         <div className='Create'>
@@ -122,6 +145,9 @@ function Create() {
                 <Navbar username={username} page={"create"} />
             </header>
             <main>
+                <Box display="flex" justifyContent="center" textAlign="center" mt="1em">
+                    <CustomName stitchId={stitchId} />
+                </Box>
                 <Box width="100%" display="flex" justifyContent="space-evenly">
                     <Box className="searchSection" color="white" minHeight="100vh" display="flex" flexDirection="column" alignItems="center" flex="1" mt="2em">
                         <Heading as='h3' size='xl'>Add Songs</Heading>
@@ -147,6 +173,25 @@ function Create() {
                                 />
                             ))}
                         </Box>
+                    </Box>
+                    <Box mt="2em">
+                        <Button
+                            className="finalizeStitch"
+                            bgGradient="linear(to-r, rgba(115, 41, 123, 0.9), rgb(83, 41, 140, 0.9))"
+                            color="white"
+                            width="10em"
+                            _focus={{ boxShadow: 'none', bg: 'white', color: 'black' }}
+                            _active={{ boxShadow: 'none' }}
+                            _hover={{
+                                opacity: 1,
+                                backgroundSize: 'auto',
+                                boxShadow: '0 0 20px -2px rgba(195, 111, 199, .5)',
+                                transform: 'translate3d(0, -0.5px, 0) scale(1.01)',
+                            }}
+                            onClick={finalizeStitch}
+                        >
+                            <Text fontSize="lg">Finalize Stitch</Text>
+                        </Button>
                     </Box>
                     <Box className="stitchSection" color="white" minHeight="100vh" display="flex" flexDirection="column" alignItems="center" flex="1" mt="2em">
                         <Heading as='h3' size='xl'>Current Stitch</Heading>

--- a/front-end/src/CustomName.jsx
+++ b/front-end/src/CustomName.jsx
@@ -1,0 +1,113 @@
+import {
+    Editable,
+    EditableInput,
+    EditablePreview,
+    useEditableControls,
+    ButtonGroup,
+    IconButton,
+    Flex,
+    Input,
+    Box
+} from '@chakra-ui/react';
+import { CheckIcon, CloseIcon, EditIcon } from '@chakra-ui/icons';
+import { useState, useEffect } from 'react';
+
+const CustomName = ({ stitchId }) => {
+    const [title, setTitle] = useState('Untitled');
+    const [revTitle, setRevTitle] = useState('Untitled');
+
+    const handleChange = (event) => {
+        setTitle(event.target.value);
+    };
+
+    const handleSubmit = async () => {
+        if (!title) {
+            setTitle('Untitled');
+            return;
+        }
+
+        try {
+            const response = await fetch(`${import.meta.env.VITE_BACKEND_ADDRESS}/stitch/title`, {
+                method: 'PATCH',
+                headers: {
+                    'Content-Type': 'application/json',
+                },
+                body: JSON.stringify({ stitchId, title }),
+            });
+
+            if (!response.ok) {
+                throw new Error('Failed to update stitch name');
+            }
+
+            setRevTitle(title);
+        } catch (error) {
+            console.error('Error updating stitch name:', error);
+        }
+    };
+
+    const handleAbort = () => {
+        setTitle(revTitle);
+    };
+
+    useEffect(() => {
+        const fetchStitchName = async () => {
+            try {
+                const url = `${import.meta.env.VITE_BACKEND_ADDRESS}/stitch/title/${stitchId}`;
+                const response = await fetch(url);
+
+                if (!response.ok) {
+                    throw new Error('Failed to fetch stitch name');
+                }
+
+                const data = await response.json();
+                setTitle(data.title || 'Untitled');
+                setRevTitle(data.title || 'Untitled');
+            } catch (error) {
+                console.error('Error fetching stitch name:', error);
+            }
+        };
+
+        fetchStitchName();
+    }, [stitchId]);
+
+    const EditableControls = () => {
+        const {
+            isEditing,
+            getSubmitButtonProps,
+            getCancelButtonProps,
+            getEditButtonProps,
+        } = useEditableControls();
+
+        return isEditing ? (
+            <ButtonGroup justifyContent='center' size='sm'>
+                <IconButton icon={<CheckIcon />} {...getSubmitButtonProps()} />
+                <IconButton icon={<CloseIcon />} {...getCancelButtonProps()} />
+            </ButtonGroup>
+        ) : (
+            <Flex justifyContent='center'>
+                <IconButton size='sm' onClick={() => setRevTitle(title)} icon={<EditIcon />} {...getEditButtonProps()} />
+            </Flex>
+        );
+    };
+
+    return (
+        <Box width="40em">
+            <Editable
+                textAlign='center'
+                fontSize='4xl'
+                fontWeight='bold'
+                color='white'
+                value={title}
+                isPreviewFocusable={false}
+                onSubmit={handleSubmit}
+                onCancel={handleAbort}
+            >
+                <EditablePreview />
+                <Input as={EditableInput} focusBorderColor='rgb(83, 41, 140)' fontSize='3xl' onChange={handleChange}/>
+                <EditableControls />
+            </Editable>
+        </Box>
+    );
+};
+
+export default CustomName;

--- a/front-end/src/Navbar.jsx
+++ b/front-end/src/Navbar.jsx
@@ -79,6 +79,8 @@ function Navbar({ username, page }) {
                     px={6}
                     py={3}
                     marginRight='1em'
+                    _focus={{ boxShadow: 'none', bg: 'white', color: 'black' }}
+                    _active={{ boxShadow: 'none' }}
                     _hover={{
                         opacity: 1,
                         backgroundSize: 'auto',
@@ -96,6 +98,8 @@ function Navbar({ username, page }) {
                         icon={<HamburgerIcon />}
                         bgGradient="linear(to-r, rgba(115, 41, 123, 0.9), rgb(83, 41, 140, 0.9))"
                         color={'white'}
+                        _focus={{ boxShadow: 'none' }}
+                        _active={{ boxShadow: 'none', bg: 'white', color: 'black' }}
                         _hover={{
                             opacity: 1,
                             backgroundSize: 'auto',

--- a/front-end/src/Song.css
+++ b/front-end/src/Song.css
@@ -1,5 +1,4 @@
 #song {
-    width: 400px;
     transition: all 0.3s ease;
     display: flex;
     background-color: rgba(225, 225, 225, 0.8);

--- a/front-end/src/Song.jsx
+++ b/front-end/src/Song.jsx
@@ -48,7 +48,7 @@ function Song({ track, onPlay, location, onAdd, onRemove }) {
                     whiteSpace="nowrap"
                     overflow="hidden"
                     textOverflow="ellipsis"
-                    width="20em"
+                    width="10em"
                 >
                     {name}
                 </Text>
@@ -60,7 +60,7 @@ function Song({ track, onPlay, location, onAdd, onRemove }) {
                     whiteSpace="nowrap"
                     overflow="hidden"
                     textOverflow="ellipsis"
-                    width="20em"
+                    width="10em"
                 >
                     {artists.map(artist => artist.name).join(', ')}
                 </Text>
@@ -71,7 +71,7 @@ function Song({ track, onPlay, location, onAdd, onRemove }) {
                     whiteSpace="nowrap"
                     overflow="hidden"
                     textOverflow="ellipsis"
-                    width="20em"
+                    width="10em"
                 >
                     {album.name}
                 </Text>
@@ -79,11 +79,11 @@ function Song({ track, onPlay, location, onAdd, onRemove }) {
             <Box ml="auto" textAlign="center" display="flex" alignItems="center" position="relative">
                 <Box mr={2}>
                     {preview_url ? (
-                        <audio ref={audioRef} controls style={{ width: '6.5em' }} onPlay={handlePlay}>
+                        <audio ref={audioRef} controls style={{ width: '15em' }} onPlay={handlePlay}>
                             <source src={preview_url} type="audio/mpeg" />
                         </audio>
                     ) : (
-                        <Box width="6.5em">
+                        <Box width="15em">
                             <Text id="duration" fontSize="0.6em" mr={3}>Audio not available</Text>
                         </Box>
                     )}

--- a/front-end/src/Stitch.jsx
+++ b/front-end/src/Stitch.jsx
@@ -1,0 +1,68 @@
+import { Heading, Box, Flex, Image, Text, IconButton } from '@chakra-ui/react';
+import { DeleteIcon } from '@chakra-ui/icons'
+import { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+
+function Stitch({ stitch, username, deleteStitch }) {
+    const [isHovered, setIsHovered] = useState(false);
+    const navigate = useNavigate();
+
+    const handleEdit = (stitchId) => () => {
+        navigate(`/${username}/create`, { state: { stitchId } });
+    };
+
+    return (
+        <Box
+            onMouseEnter={() => setIsHovered(true)}
+            onMouseLeave={() => setIsHovered(false)}
+            variant='elevated'
+            borderRadius='md'
+            bgColor='white'
+            color='black'
+            boxShadow='md'
+            overflow='hidden'
+            transition='transform 0.2s'
+            _hover={{
+                transform: 'scale(1.05)',
+                cursor: 'pointer',
+                boxShadow: 'lg',
+            }}
+            onClick={handleEdit(stitch.id)}
+            position="relative"
+        >
+            <Image
+                src={stitch.imageUrl}
+                alt='Stitch Cover Image'
+                objectFit='cover'
+                borderTopRadius='md'
+                width='100%'
+                height='70%'
+            />
+            <Box p={4}>
+                <Heading size='md' mb={2} whiteSpace="nowrap" width="7.5em" overflow="hidden" textOverflow="ellipsis">{stitch.title}</Heading>
+                <Flex align="center">
+                    <Text fontSize='sm' color='black' mr={2}>Created by {username}</Text>
+                    {isHovered && (
+                        <IconButton
+                            icon={<DeleteIcon />}
+                            onClick={deleteStitch(stitch.id)}
+                            position="absolute"
+                            right={2}
+                            bottom={2}
+                            bg="black"
+                            color="white"
+                            _focus={{ boxShadow: 'none' }}
+                            _active={{ boxShadow: 'none', bg: 'white', color: 'black' }}
+                            _hover={{
+                                opacity: 1,
+                                backgroundSize: 'auto',
+                                transform: 'translate3d(0, -0.5px, 0) scale(1.01)'
+                            }}/>
+                    )}
+                </Flex>
+            </Box>
+        </Box>
+    );
+}
+
+export default Stitch;


### PR DESCRIPTION
**Prisma**

- Updated stitch model to hold an imageUrl that corresponds with the top song on the playlist. 

**Backend**

- Adjusted get method for songs so that they would always be in the order of adding (ascending ids). 
- For stitches I created two "patch" routes in order to update the image and title when user makes changes. 
- Also changed get method to send the most recent stitch first (descending by id). 
- Revised the delete for stitches as I have to delete the songs before I can delete the stitch itself. 

**Frontend**

- Incorporated frontend to rename stitch and update stitch image with topmost song. 
- Also added editing feature in the frontend that takes you to the create screen of the stitch you select. 
- Added delete button on hover that deletes stitch. 
- Added finalize button that takes user back to home screen with created stitch.
- Adjusted the length of the audio section of songs so user can edit what part of the 30 second preview they want to listen to.

**GIF for functionality**
![Screen Recording 2024-07-12 at 9 47 49 AM (1)](https://github.com/user-attachments/assets/331c3a14-fbc2-4821-94ce-b881c109dd7c)

**Screens to show better quality**

<img width="1728" alt="Screenshot 2024-07-12 at 10 01 18 AM" src="https://github.com/user-attachments/assets/9e92eda9-e2e5-44d7-9f13-0ac4db083154">
<img width="1728" alt="Screenshot 2024-07-12 at 10 01 26 AM" src="https://github.com/user-attachments/assets/81738730-bd11-4a53-ab1f-0d5baedccd7a">

