### PR TITLE
[prisma][node.js][react] Finished TC1 and last MVP Feature (View Profile). Started implementing Spotify export stretch feature and resolved too many recommendation request issue.

### DIFF
--- a/back-end/prisma/migrations/20240718164905_add_spotify_id_to_stitch_for_exporting/migration.sql
+++ b/back-end/prisma/migrations/20240718164905_add_spotify_id_to_stitch_for_exporting/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "Stitch" ADD COLUMN     "spotifyId" TEXT DEFAULT '';

--- a/back-end/prisma/schema.prisma
+++ b/back-end/prisma/schema.prisma
@@ -30,7 +30,7 @@ model Token {
 }
 
 model Stitch {
-  id          Int  @id @default(autoincrement())
+  id          Int     @id @default(autoincrement())
   title       String
   duration    Int
   imageUrl    String
@@ -39,8 +39,9 @@ model Stitch {
   dance       Float
   mix         Float
   explore     Float
-  User        User  @relation(fields: [userId], references: [id])
+  User        User    @relation(fields: [userId], references: [id])
   userId      Int
+  spotifyId   String? @default("")
 }
 
 model Song {

--- a/back-end/routes/stitchRoutes.js
+++ b/back-end/routes/stitchRoutes.js
@@ -65,9 +65,20 @@ router.post('/create', async (req, res) => {
     })
 
     const totalPreferences = mood + dance + mix;
-    const moodWeight = mood / totalPreferences;
-    const danceWeight = dance / totalPreferences;
-    const mixWeight = 1 - (moodWeight + danceWeight);
+
+    let moodWeight = null;
+    let danceWeight = null;
+    let mixWeight = null;
+
+    if (totalPreferences == 0) {
+        moodWeight = 0;
+        danceWeight = 0;
+        mixWeight = 0;
+    } else {
+        moodWeight = mood / totalPreferences;
+        danceWeight = dance / totalPreferences;
+        mixWeight = 1 - (moodWeight + danceWeight);
+    }
 
     const newStitch = await prisma.stitch.create({
         data: {
@@ -94,7 +105,7 @@ router.patch('/title', async (req, res) => {
     try {
         const updatedStitch = await prisma.stitch.update({
             where: {
-                id: parseInt(stitchId, 10)
+                id: parseInt(stitchId)
             },
             data: {
                 title
@@ -109,7 +120,7 @@ router.patch('/title', async (req, res) => {
 
 router.patch('/image', async (req, res) => {
     const { stitchId, imageUrl } = req.body;
-    
+
     if (!stitchId || !imageUrl) {
         return res.status(400).json({ error: 'stitchId and imageUrl are required' });
     }
@@ -117,13 +128,33 @@ router.patch('/image', async (req, res) => {
     try {
         const updatedStitch = await prisma.stitch.update({
             where: {
-                id: parseInt(stitchId, 10)
+                id: parseInt(stitchId)
             },
             data: {
                 imageUrl
             }
         });
         res.json(updatedStitch);
+    } catch (error) {
+        console.error('Error updating stitch:', error);
+        res.status(500).json({ error: 'Failed to update stitch.' });
+    }
+});
+
+router.patch('/exportToSpotify', async (req, res) => {
+    const { stitchId } = req.body;
+
+    if (!stitchId) {
+        return res.status(400).json({ error: 'stitchId and title are required' });
+    }
+
+    try {
+        const stitch = await prisma.stitch.findUnique({
+            where: {
+                id: parseInt(stitchId)
+            },
+        });
+
     } catch (error) {
         console.error('Error updating stitch:', error);
         res.status(500).json({ error: 'Failed to update stitch.' });
@@ -158,7 +189,7 @@ router.delete('/:id', async (req, res) => {
 
                 } catch (error) {
                     console.error('Error deleting song:', error);
-                    throw error; 
+                    throw error;
                 }
             });
 

--- a/front-end/src/Home.jsx
+++ b/front-end/src/Home.jsx
@@ -58,7 +58,7 @@ function Home() {
                     <Heading as='h2' size='2xl'>Your Stitches</Heading>
                 </Box>
                 {stitches && (
-                    <SimpleGrid spacing={4} p={10} templateColumns='repeat(auto-fill, minmax(200px, 1fr))'>
+                    <SimpleGrid spacing={6} p={7} templateColumns='repeat(auto-fill, minmax(200px, 1fr))'>
                         {stitches.map((stitch) => (
                             <Stitch key={stitch.id} stitch={stitch} username={username} deleteStitch={deleteStitch}/>
                         ))}

--- a/front-end/src/Song.css
+++ b/front-end/src/Song.css
@@ -20,11 +20,6 @@
     height: 3em;
 }
 
-#songDetails {
-    margin-left: 1em;
-    flex: 1; 
-}
-
 #songName,
 #artist,
 #album {

--- a/front-end/src/Song.jsx
+++ b/front-end/src/Song.jsx
@@ -39,7 +39,7 @@ function Song({ track, onPlay, location, onAdd, onRemove }) {
             maxWidth="600px"
         >
             <Image className="songImage" src={album.images[0].url} alt="Song Image" width="4em" height="3em" />
-            <Box id="songDetails" ml="1em" flex="1">
+            <Box id="songDetails" ml="1em">
                 <Text
                     id="songName"
                     fontSize="0.8em"

--- a/front-end/src/Stitch.jsx
+++ b/front-end/src/Stitch.jsx
@@ -1,5 +1,5 @@
 import { Heading, Box, Flex, Image, Text, IconButton } from '@chakra-ui/react';
-import { DeleteIcon } from '@chakra-ui/icons'
+import { MinusIcon, ExternalLinkIcon } from '@chakra-ui/icons'
 import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 
@@ -9,6 +9,25 @@ function Stitch({ stitch, username, deleteStitch }) {
 
     const handleEdit = (stitchId) => () => {
         navigate(`/${username}/create`, { state: { stitchId } });
+    };
+
+    const handleShareToSpotify = () => (event) => {
+        event.stopPropagation();
+        exportToSpotify(stitch.id);
+    };
+
+    const exportToSpotify = async (stitchId) => {
+        try {
+            const response = await fetch(`${import.meta.env.VITE_BACKEND_ADDRESS}/stitch/exportToSpotify`, {
+                method: 'PATCH',
+                headers: {
+                    'Content-Type': 'application/json'
+                },
+                body: JSON.stringify({ stitchId })
+            });
+        } catch (error) {
+            console.error('Error exportin stitch to Spotify:', error);
+        }
     };
 
     return (
@@ -43,14 +62,15 @@ function Stitch({ stitch, username, deleteStitch }) {
                 <Flex align="center">
                     <Text fontSize='sm' color='black' mr={2}>Created by {username}</Text>
                     {isHovered && (
-                        <IconButton
-                            icon={<DeleteIcon />}
+                        <Box>
+                            <IconButton
+                            icon={<MinusIcon />}
                             onClick={deleteStitch(stitch.id)}
                             position="absolute"
                             right={2}
-                            bottom={2}
-                            bg="black"
-                            color="white"
+                            top={2}
+                            bg="white"
+                            color="black"
                             _focus={{ boxShadow: 'none' }}
                             _active={{ boxShadow: 'none', bg: 'white', color: 'black' }}
                             _hover={{
@@ -58,6 +78,23 @@ function Stitch({ stitch, username, deleteStitch }) {
                                 backgroundSize: 'auto',
                                 transform: 'translate3d(0, -0.5px, 0) scale(1.01)'
                             }}/>
+                            <IconButton
+                            icon={<ExternalLinkIcon />}
+                            onClick={handleShareToSpotify()}
+                            position="absolute"
+                            right={2}
+                            bottom={2}
+                            bg="white"
+                            color="black"
+                            size="lg"
+                            _focus={{ boxShadow: 'none' }}
+                            _active={{ boxShadow: 'none', bg: 'white', color: 'black' }}
+                            _hover={{
+                                opacity: 1,
+                                backgroundSize: 'auto',
+                                transform: 'translate3d(0, -0.5px, 0) scale(1.01)'
+                            }}/>
+                        </Box>
                     )}
                 </Flex>
             </Box>


### PR DESCRIPTION
**Backend**
- Debugged tonality scoring: was using mode instead of key when comparing jumps so that was leading to wrong recommendations. 
- I also added grades based on key and mode switch: same key = 1, different key 5th/same mode = 0.75, and moving from a major to a minor third = 0.5. 
- Checked in both creation for all 0 preferences to not divide by 0 and then in recommendations to just give them the basic Spotify recommendations since they have no preferences. 

**Frontend**

- Fixed issue with calling API call to many times in front-end. 
- Resolved by adding a button to get recommendations that the user can only use every 15 seconds. 
- This allows for checking to make sure the user doesn't call the API too many times. 
- Added toasts to tell the user to add a song for first set of recommendations and to wait 15 seconds if they already used it. 
- Added profile modal that can be opened from the navbar. 
- This shows the user's username, total followers, and their top 4 songs. 
- Added descriptions to the preference modal to give the user more of an idea of what they are deciding with the sliders. 

**Extra for stretch**

- Added spotify playlist id for stitches thinking ahead for exporting stitches to Spotify. 
- Started working on the export to Spotify so added share button to stitches that send the stitchId to the backend.


**Example of Mixability working properly with Camelot Wheel check and BPM**

<img width="1237" alt="Screenshot 2024-07-18 at 11 17 32 AM" src="https://github.com/user-attachments/assets/f4e11fe3-e15c-47bf-9607-a728737154dc">

These were the rankings of the songs in recommended after selecting the song above:

- The top choice is the song with a close BPM and the same key/mode as the song in the stitch.
- Even though the first and second choice have the same BPM, moving into the same key will be a better transition.
- The second and third choice are both 5th's away from the song in the stitch, but the second is above because it has closer BPM.

1. <img width="1229" alt="Screenshot 2024-07-18 at 11 17 39 AM" src="https://github.com/user-attachments/assets/fe1d2e7f-0b80-496d-b509-17c75723fa0c">
2. <img width="1249" alt="Screenshot 2024-07-18 at 11 17 46 AM" src="https://github.com/user-attachments/assets/e741cbbb-dda5-4a5a-8c6f-5d01c5a544c1">
3. <img width="1228" alt="Screenshot 2024-07-18 at 11 17 52 AM" src="https://github.com/user-attachments/assets/998cf82b-403d-45ed-9423-197c425847c3">

After selecting choice number one, this was my new first choice recommendation.

<img width="1118" alt="Screenshot 2024-07-18 at 11 37 41 AM" src="https://github.com/user-attachments/assets/e221ab63-56a1-4492-95b6-2cd4613d5e77">

**These are two screenshots showing the toasts implemented**

1. When the user has nothing in their stitch.
<img width="1728" alt="Screenshot 2024-07-18 at 11 53 12 AM" src="https://github.com/user-attachments/assets/266b8932-fd06-4692-b84c-128edc7c6d94">

2. When the user needs to wait to get more recommendations (protecting against too many API calls).
<img width="1728" alt="Screenshot 2024-07-18 at 12 41 57 PM" src="https://github.com/user-attachments/assets/ae2a1fa1-caf4-401e-a7a9-aa3be4265c56">


**View Profile Feature**

<img width="1728" alt="Screenshot 2024-07-18 at 12 15 26 PM" src="https://github.com/user-attachments/assets/99bccc8b-bef1-4647-9381-b7225341a3bc">

**Descriptions on preference modal**

<img width="1728" alt="Screenshot 2024-07-18 at 12 15 36 PM" src="https://github.com/user-attachments/assets/864b4f41-2156-45b6-b824-34ec30242331">
