### PR TITLE
[react] Wrapped up MVP of TC2 and did a stretch goal of TC2 which was to have images for the songs displaying in the cluster circles.

### DIFF
--- a/back-end/routes/clusters.js
+++ b/back-end/routes/clusters.js
@@ -198,7 +198,6 @@ router.get('/:stitchId', async (req, res) => {
         const numClusters = Math.ceil(stitch.songs.length / 3);
         const clusteringResult = kMeans(valenceFeatures, numClusters);
         const clustersWithTrackInfo = await addClusterToSong(stitch.songs, clusteringResult);
-        
         res.status(200).json(clustersWithTrackInfo);
     } catch (error) {
         res.status(500).json({ error: 'Failed to retrieve clusters.' });

--- a/front-end/src/App.jsx
+++ b/front-end/src/App.jsx
@@ -3,7 +3,7 @@ import Create from './Create';
 import SpotifyLogin from './SpotifyLogin';
 import SpotifyCallback from './SpotifyCallback';
 import Visualization from './visualization/Visualization';
-import { BrowserRouter, Routes, Route, Navigate } from "react-router-dom";
+import { BrowserRouter, Routes, Route } from "react-router-dom";
 
 function App() {
   return (

--- a/front-end/src/Create.jsx
+++ b/front-end/src/Create.jsx
@@ -4,6 +4,7 @@ import { Box, Input, FormControl, Heading, Button, Text, useToast } from '@chakr
 import Navbar from './Navbar';
 import Song from './Song';
 import CustomName from './CustomName';
+import Footer from './Footer';
 import noImage from './assets/Image_not_available.png';
 
 function Create() {
@@ -160,7 +161,7 @@ function Create() {
     };
 
     const handleToVisualization = () => {
-        navigate(`/${username}/visualization`);
+        navigate(`/${username}/visualization`, { state: { stitchId } });
     }
 
     useEffect(() => {
@@ -183,7 +184,7 @@ function Create() {
     }, [deleteId, stitchId]);
 
     return (
-        <div className='Create'>
+        <Box className='Create'>
             <header>
                 <Navbar username={username} page={"create"} />
             </header>
@@ -248,6 +249,24 @@ function Create() {
                     </Box>
                     <Box mt="2em" display='flex' flexDirection='column' alignItems='center'>
                         <Button
+                            className="navigateToVisualization"
+                            bgGradient="linear(to-r, rgba(115, 41, 123, 0.9), rgb(83, 41, 140, 0.9))"
+                            color="white"
+                            width="11em"
+                            mb="1em"
+                            _focus={{ boxShadow: 'none', bg: 'white', color: 'black' }}
+                            _active={{ boxShadow: 'none' }}
+                            _hover={{
+                                opacity: 1,
+                                backgroundSize: 'auto',
+                                boxShadow: '0 0 20px -2px rgba(195, 111, 199, .5)',
+                                transform: 'translate3d(0, -0.5px, 0) scale(1.01)',
+                            }}
+                            onClick={handleToVisualization}
+                        >
+                            <Text fontSize="lg">View Visualization</Text>
+                        </Button>
+                        <Button
                             className="finalizeStitch"
                             bgGradient="linear(to-r, rgba(115, 41, 123, 0.9), rgb(83, 41, 140, 0.9))"
                             color="white"
@@ -264,24 +283,7 @@ function Create() {
                         >
                             <Text fontSize="lg">Finalize Stitch</Text>
                         </Button>
-                        <Button
-                            className="navigateToVisualization"
-                            bgGradient="linear(to-r, rgba(115, 41, 123, 0.9), rgb(83, 41, 140, 0.9))"
-                            color="white"
-                            width="11em"
-                            mt="1em"
-                            _focus={{ boxShadow: 'none', bg: 'white', color: 'black' }}
-                            _active={{ boxShadow: 'none' }}
-                            _hover={{
-                                opacity: 1,
-                                backgroundSize: 'auto',
-                                boxShadow: '0 0 20px -2px rgba(195, 111, 199, .5)',
-                                transform: 'translate3d(0, -0.5px, 0) scale(1.01)',
-                            }}
-                            onClick={handleToVisualization}
-                        >
-                            <Text fontSize="lg">View Visualization</Text>
-                        </Button>
+
                     </Box>
                     <Box className="stitchSection" color="white" minHeight="100vh" display="flex" flexDirection="column" alignItems="center" flex="1" mt="2em">
                         <Heading as='h3' size='xl'>Current Stitch</Heading>
@@ -299,7 +301,10 @@ function Create() {
                     </Box>
                 </Box>
             </main>
-        </div>
+            <footer>
+                <Footer />
+            </footer>
+        </Box>
     )
 }
 

--- a/front-end/src/Footer.jsx
+++ b/front-end/src/Footer.jsx
@@ -1,0 +1,14 @@
+import { Box, Text } from '@chakra-ui/react';
+
+function Footer() {
+    return (
+        <Box padding='2em' mt='1em' textAlign='center' alignItems='center' bg='black'>
+            <Text>Diego Landaeta Torres</Text>
+            <Text mt='1em'>Meta University Summer 2024</Text>
+        </Box>
+    )
+}
+
+export default Footer;
+
+

--- a/front-end/src/Home.jsx
+++ b/front-end/src/Home.jsx
@@ -4,6 +4,7 @@ import { Heading, Box, SimpleGrid } from '@chakra-ui/react';
 import { useParams } from 'react-router-dom';
 import { useState, useEffect } from 'react';
 import Stitch from './Stitch';
+import Footer from './Footer';
 
 function Home() {
     const params = useParams();
@@ -49,7 +50,7 @@ function Home() {
     }, [deleteId, username]);
 
     return (
-        <div className='Home'>
+        <Box className='Home' display='flex' flexDirection='column' minHeight='100vh'>
             <header>
                 <Navbar username={username} page={"home"} />
             </header>
@@ -65,7 +66,10 @@ function Home() {
                     </SimpleGrid>
                 )}
             </main>
-        </div>
+            <footer>
+                <Footer />
+            </footer>
+        </Box>
     );
 }
 

--- a/front-end/src/Stitch.jsx
+++ b/front-end/src/Stitch.jsx
@@ -1,5 +1,5 @@
-import { Heading, Box, Flex, Image, Text, IconButton } from '@chakra-ui/react';
-import { MinusIcon, ExternalLinkIcon } from '@chakra-ui/icons'
+import { Heading, Box, Flex, Image, Text, IconButton, Tooltip } from '@chakra-ui/react';
+import { DeleteIcon, ExternalLinkIcon } from '@chakra-ui/icons'
 import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 
@@ -63,37 +63,41 @@ function Stitch({ stitch, username, deleteStitch }) {
                     <Text fontSize='sm' color='black' mr={2}>Created by {username}</Text>
                     {isHovered && (
                         <Box>
+                            <Tooltip label='Delete from library' placement='bottom'>
                             <IconButton
-                            icon={<MinusIcon />}
-                            onClick={deleteStitch(stitch.id)}
-                            position="absolute"
-                            right={2}
-                            top={2}
-                            bg="white"
-                            color="black"
-                            _focus={{ boxShadow: 'none' }}
-                            _active={{ boxShadow: 'none', bg: 'white', color: 'black' }}
-                            _hover={{
-                                opacity: 1,
-                                backgroundSize: 'auto',
-                                transform: 'translate3d(0, -0.5px, 0) scale(1.01)'
-                            }}/>
-                            <IconButton
-                            icon={<ExternalLinkIcon />}
-                            onClick={handleShareToSpotify()}
-                            position="absolute"
-                            right={2}
-                            bottom={2}
-                            bg="white"
-                            color="black"
-                            size="lg"
-                            _focus={{ boxShadow: 'none' }}
-                            _active={{ boxShadow: 'none', bg: 'white', color: 'black' }}
-                            _hover={{
-                                opacity: 1,
-                                backgroundSize: 'auto',
-                                transform: 'translate3d(0, -0.5px, 0) scale(1.01)'
-                            }}/>
+                                icon={<DeleteIcon />}
+                                onClick={deleteStitch(stitch.id)}
+                                position="absolute"
+                                right={2}
+                                top={2}
+                                bg="white"
+                                color="black"
+                                _focus={{ boxShadow: 'none' }}
+                                _active={{ boxShadow: 'none', bg: 'white', color: 'black' }}
+                                _hover={{
+                                    opacity: 1,
+                                    backgroundSize: 'auto',
+                                    transform: 'translate3d(0, -0.5px, 0) scale(1.01)'
+                                }} />
+                            </Tooltip>
+                            <Tooltip label='Export to Spotify' placement='bottom'>
+                                <IconButton
+                                    icon={<ExternalLinkIcon />}
+                                    onClick={handleShareToSpotify()}
+                                    position="absolute"
+                                    right={2}
+                                    bottom={2}
+                                    bg="white"
+                                    color="black"
+                                    size="lg"
+                                    _focus={{ boxShadow: 'none' }}
+                                    _active={{ boxShadow: 'none', bg: 'white', color: 'black' }}
+                                    _hover={{
+                                        opacity: 1,
+                                        backgroundSize: 'auto',
+                                        transform: 'translate3d(0, -0.5px, 0) scale(1.01)'
+                                    }} />
+                            </Tooltip>
                         </Box>
                     )}
                 </Flex>

--- a/front-end/src/index.css
+++ b/front-end/src/index.css
@@ -4,6 +4,6 @@ html, body {
   padding: 0;
 }
 
-#root {
-  height: 100%;
+main {
+  flex: 1;
 }

--- a/front-end/src/visualization/Edge.jsx
+++ b/front-end/src/visualization/Edge.jsx
@@ -3,8 +3,8 @@ import { Box } from '@chakra-ui/react';
 const Edge = ({ from, to, color }) => {
     const startX = from.x + 25;
     const startY = from.y + 25;
-    const endX = to.x + 25; 
-    const endY = to.y + 25;
+    const endX = to.x; 
+    const endY = to.y;
 
     const angle = Math.atan2(endY - startY, endX - startX) * 180 / Math.PI;
     const length = Math.sqrt((endX - startX) ** 2 + (endY - startY) ** 2);

--- a/front-end/src/visualization/Node.jsx
+++ b/front-end/src/visualization/Node.jsx
@@ -1,4 +1,4 @@
-import { Box } from '@chakra-ui/react';
+import { Box, Image, Text } from '@chakra-ui/react';
 
 const Node = ({ node }) => {
     return (
@@ -9,15 +9,28 @@ const Node = ({ node }) => {
             width="50px"
             height="50px"
             borderRadius="50%"
-            backgroundColor={node.color}
-            color="white"
+            backgroundColor={node.isCluster ? node.color : 'transparent'}
             display="flex"
+            flexDirection="column"
             alignItems="center"
             justifyContent="center"
             cursor="pointer"
             userSelect="none"
         >
-            {node.label}
+            {node.isCluster ? (
+                <Box width="100%" height="100%" display="flex" alignItems="center" justifyContent="center">
+                </Box>
+            ) : (
+                <Image
+                    src={node.imageUrl}
+                    alt={node.label}
+                    boxSize="100%"
+                    objectFit="cover"
+                />
+            )}
+            <Text color="white" fontSize="xs" mt={node.isCluster ? 0 : 2} textAlign="center">
+                {node.label}
+            </Text>
         </Box>
     );
 };

--- a/front-end/src/visualization/Visualization.jsx
+++ b/front-end/src/visualization/Visualization.jsx
@@ -1,13 +1,20 @@
-import { Box, Flex, Button } from '@chakra-ui/react';
+import { Box, Flex, Button, Text, Heading } from '@chakra-ui/react';
 import Graph from './Graph';
 import Navbar from '../Navbar';
-import { useParams } from 'react-router-dom';
-import { useState } from 'react';
+import Footer from '../Footer';
+import { useParams, useNavigate, useLocation } from 'react-router-dom';
+import { useState, useEffect } from 'react';
 
 function Visualization() {
     const params = useParams();
     const username = params.username;
+    const location = useLocation();
+    const navigate = useNavigate();
+    const stitchId = location.state.stitchId;
     const [zoomLevel, setZoomLevel] = useState(1);
+    const [clusterData, setClusterData] = useState({ centroids: [], assignments: [] });
+    const [graphData, setGraphData] = useState({ nodes: [], edges: [] });
+    const [title, setTitle] = useState('');
 
     const zoomIn = () => {
         setZoomLevel(prevZoom => Math.min(prevZoom * 1.1, 2));
@@ -50,47 +57,115 @@ function Visualization() {
         return positions;
     }
 
-    function generateClusterData(clusterId, clusterLabel, centerX, centerY, songCount, radius) {
-        const clusterColor = getRandomColor();
-        const songPositions = calculateCircularPositions(centerX, centerY, radius, songCount);
-        const nodes = [{ id: clusterId, label: clusterLabel, x: centerX, y: centerY, isCluster: true, color: clusterColor }];
-        const edges = [];
+    function generateClusterData(clusterData, clusterPositions) {
+        let globalId = 1;
+        let allNodes = [];
+        let allEdges = [];
 
-        songPositions.forEach((pos, index) => {
-            const songId = clusterId * 100 + index + 1;
-            nodes.push({ id: songId, label: `Song ${index + 1}`, x: pos.x, y: pos.y, color: clusterColor });
-            edges.push({ from: clusterId, to: songId, color: 'white' });
+        clusterData.centroids.forEach((centroid, index) => {
+            const formattedCentroid = clusterData.centroids[index]?.toFixed(2) || '0.00';
+            const clusterLabel = `Valence: ${formattedCentroid}`;
+            const { x, y } = clusterPositions[index];
+            const songsInCluster = clusterData.assignments.filter(song => song.cluster === index);
+            const songPositions = calculateCircularPositions(x, y, 100, songsInCluster.length);
+            const clusterColor = getRandomColor();
+
+            const nodes = [{ id: globalId++, label: clusterLabel, x, y, isCluster: true, color: clusterColor }];
+            const edges = [];
+
+            songsInCluster.forEach((song, idx) => {
+                nodes.push({
+                    id: song.id,
+                    label: song.name,
+                    x: songPositions[idx].x,
+                    y: songPositions[idx].y,
+                    color: clusterColor,
+                    imageUrl: song.album.images[0].url
+                });
+                edges.push({ from: globalId - 1, to: song.id, color: 'white' });
+            });
+
+            allNodes = allNodes.concat(nodes);
+            allEdges = allEdges.concat(edges);
         });
 
-        return { nodes, edges };
+        return { nodes: allNodes, edges: allEdges };
     }
 
-    function addInterClusterEdges(nodes, edges) {
-        const song1 = nodes.find(node => node.label === 'Song 1' && node.id > 100 && node.id < 200);
-        const song3 = nodes.find(node => node.label === 'Song 3' && node.id > 200 && node.id < 300);
-        if (song1 && song3) {
-            edges.push({
-                from: song1.id,
-                to: song3.id,
-                color: 'red'
-            });
+    useEffect(() => {
+        const getClusterData = async () => {
+            try {
+                const response = await fetch(`${import.meta.env.VITE_BACKEND_ADDRESS}/clusters/${stitchId}`);
+                const data = await response.json();
+                setClusterData(data);
+            } catch (error) {
+                console.error('Error getting clusters:', error);
+            }
+        };
+
+        const fetchStitchName = async () => {
+            try {
+                const url = `${import.meta.env.VITE_BACKEND_ADDRESS}/stitch/title/${stitchId}`;
+                const response = await fetch(url);
+
+                if (!response.ok) {
+                    throw new Error('Failed to fetch stitch name');
+                }
+
+                const data = await response.json();
+                setTitle(data.title || 'Untitled');
+            } catch (error) {
+                console.error('Error fetching stitch name:', error);
+            }
+        };
+
+        fetchStitchName();
+        getClusterData();
+    }, []);
+
+    useEffect(() => {
+        if (clusterData.centroids.length > 0) {
+            const clusterPositions = calculateClusterPositions(clusterData.centroids.length, 1000, 1000, 250);
+            const { nodes, edges } = generateClusterData(clusterData, clusterPositions);
+            setGraphData({ nodes, edges });
         }
+    }, [clusterData]);
+
+    const handleToStitch = () => {
+        navigate(`/${username}/create`, { state: { stitchId } });
     }
 
-    const clusterPositions = calculateClusterPositions(3, 1000, 1000, 200);
-    let globalId = 1;
-    let allNodes = [];
-    let allEdges = [];
-    clusterPositions.forEach((pos, index) => {
-        const clusterData = generateClusterData(globalId++, `Cluster ${index + 1}`, pos.x, pos.y, 5, 70);
-        allNodes = allNodes.concat(clusterData.nodes);
-        allEdges = allEdges.concat(clusterData.edges);
-    });
-    addInterClusterEdges(allNodes, allEdges);
+
     return (
         <div className='Visualization'>
             <header>
                 <Navbar username={username} page={"visualization"} />
+                <Flex justifyContent="center" mt="1em">
+                    <Heading size='2xl'>{title}</Heading>
+                </Flex>
+                <Flex justifyContent="center">
+                    <Button
+                        className="navigateToVisualization"
+                        bgGradient="linear(to-r, rgba(115, 41, 123, 0.9), rgb(83, 41, 140, 0.9))"
+                        color="white"
+                        width="11em"
+                        mt="1em"
+                        _focus={{ boxShadow: 'none', bg: 'white', color: 'black' }}
+                        _active={{ boxShadow: 'none' }}
+                        _hover={{
+                            opacity: 1,
+                            backgroundSize: 'auto',
+                            boxShadow: '0 0 20px -2px rgba(195, 111, 199, .5)',
+                            transform: 'translate3d(0, -0.5px, 0) scale(1.01)',
+                        }}
+                        onClick={handleToStitch}
+                    >
+                        <Text fontSize="lg">Back to Stitch</Text>
+                    </Button>
+                </Flex>
+                <Flex justifyContent='center'>
+                    <Text color='white' fontSize='md' mt='1.5em' textAlign='center' width='70%'>According to Spotify, a value on valence that's closer to 1.0 will describe happy, cheerful or euphoric songs 🥳😺💃, while a value closer to 0.0 will relate sad, depressed or angry songs 😡😿💔. This visualization clusters songs with their closest valence neighbors!</Text>
+                </Flex>
                 <Flex justifyContent="center" mt="1em">
                     <Button onClick={zoomIn} m={2} colorScheme="white">Zoom In</Button>
                     <Button onClick={zoomOut} m={2} colorScheme="white">Zoom Out</Button>
@@ -106,7 +181,7 @@ function Visualization() {
                     width="100vw"
                     height="100vh"
                     position="relative"
-                    overflow="hidden"
+                    overflow="auto" 
                 >
                     <Box
                         position="absolute"
@@ -120,10 +195,13 @@ function Visualization() {
                             height: '2000px'
                         }}
                     >
-                        <Graph nodes={allNodes} edges={allEdges} />
+                        <Graph nodes={graphData.nodes} edges={graphData.edges} />
                     </Box>
                 </Box>
             </main>
+            <footer>
+                <Footer />
+            </footer>
         </div>
     );
 }


### PR DESCRIPTION
**Frontend**

- Implemented algorithm into front-end display. 
- Revised my example of clusters to now use actual data that is returned as a JSON with centroids and the assignments. Assignments are song objects with their cluster number. 
- Changed the song nodes to show the images and titles of the songs. 
- Added a footer for all of my pages. 
- Added a tooltip to describe options for stitches on home page (export to Spotify or delete from library).
- Added a description so the user understands what the clusters mean. 
- Created back to stitch button and display the stitch name in the visualization page now.

**Example of what clusters look like and visualization page**

<img width="1728" alt="Screenshot 2024-07-22 at 3 05 43 PM" src="https://github.com/user-attachments/assets/9cb870aa-c4a3-4fbd-a610-0f562838c4ea">

**Examples of tooltips: exporting to Spotify and deleting a stitch**

<img width="1728" alt="Screenshot 2024-07-22 at 3 39 47 PM" src="https://github.com/user-attachments/assets/8a7bd02a-c83e-47ea-a1b6-db55526bc919">
<img width="1728" alt="Screenshot 2024-07-22 at 3 39 51 PM" src="https://github.com/user-attachments/assets/67e74332-c0d4-4fa6-89fa-89e01b7a8f48">
