### PR TITLE
[node.js][react] Finished exporting stitches to Spotify stretch feature and implemented updating so playlists aren't created again on Spotify if they were once exported.

### DIFF
--- a/back-end/routes/audioFeaturesAndAccesToken.js
+++ b/back-end/routes/audioFeaturesAndAccesToken.js
@@ -1,0 +1,38 @@
+const { PrismaClient } = require('@prisma/client');
+const prisma = new PrismaClient();
+
+const fetchAudioFeatures = async (songs, accessToken) => {
+    const songIds = songs.map(song => (song.uri).split(':').pop());
+    const stringOfIds = songIds.join(',');
+    try {
+        const response = await fetch(`https://api.spotify.com/v1/audio-features?ids=${encodeURIComponent(stringOfIds)}`, {
+            headers: {
+                'Authorization': `Bearer ${accessToken}`
+            }
+        });
+        if (!response.ok) {
+            throw new Error(`HTTP error! status: ${response.status}`);
+        }
+        const audioData = await response.json();
+        return audioData.audio_features;
+    } catch (error) {
+        return [];
+    }
+};
+
+const getAccessToken = async (userId) => {
+    const token = await prisma.token.findFirst({
+        where: {
+            userId
+        },
+        orderBy: {
+            createdAt: 'desc'
+        }
+    });
+    return token ? token.token : null;
+};
+
+module.exports = {
+    fetchAudioFeatures,
+    getAccessToken
+};

--- a/back-end/routes/clusters.js
+++ b/back-end/routes/clusters.js
@@ -21,7 +21,6 @@ const fetchAudioFeatures = async (songs, accessToken) => {
         const audioData = await response.json();
         return audioData.audio_features;
     } catch (error) {
-        console.error(error);
         return [];
     }
 };

--- a/back-end/routes/clusters.js
+++ b/back-end/routes/clusters.js
@@ -1,41 +1,10 @@
 const express = require('express');
 const { PrismaClient } = require('@prisma/client');
-const fetch = require('node-fetch');
+const { fetchAudioFeatures, getAccessToken } = require('./audioFeaturesAndAccesToken');
 const router = express.Router();
 const prisma = new PrismaClient();
 
 router.use(express.json());
-
-const fetchAudioFeatures = async (songs, accessToken) => {
-    const songIds = songs.map(song => (song.uri).split(':').pop());
-    const stringOfIds = songIds.join(',');
-    try {
-        const response = await fetch(`https://api.spotify.com/v1/audio-features?ids=${encodeURIComponent(stringOfIds)}`, {
-            headers: {
-                'Authorization': `Bearer ${accessToken}`
-            }
-        });
-        if (!response.ok) {
-            throw new Error(`HTTP error! status: ${response.status}`);
-        }
-        const audioData = await response.json();
-        return audioData.audio_features;
-    } catch (error) {
-        return [];
-    }
-};
-
-const getAccessToken = async (userId) => {
-    const token = await prisma.token.findFirst({
-        where: {
-            userId
-        },
-        orderBy: {
-            createdAt: 'desc'
-        }
-    });
-    return token ? token.token : null;
-};
 
 function getValenceFeatures(audioFeatures) {
     const valenceFeatures = [];

--- a/back-end/routes/login.js
+++ b/back-end/routes/login.js
@@ -27,7 +27,6 @@ router.delete('/logout', async (req, res) => {
             return res.status(404).json({ error: "Token not found" })
         }
     } catch (error) {
-        console.error("Logout error:", error)
         return res.status(500).json({ error: "Internal server error" })
     }
 })

--- a/back-end/routes/recommendations.js
+++ b/back-end/routes/recommendations.js
@@ -1,43 +1,11 @@
 const express = require('express');
 const { PrismaClient } = require('@prisma/client');
+const { fetchAudioFeatures, getAccessToken } = require('./audioFeaturesAndAccesToken');
 const fetch = require('node-fetch');
 const router = express.Router();
 const prisma = new PrismaClient();
 
 router.use(express.json());
-
-const getAccessToken = async (userId) => {
-    const token = await prisma.token.findFirst({
-        where: {
-            userId
-        },
-        orderBy: {
-            createdAt: 'desc'
-        }
-    });
-    return token ? token.token : null;
-};
-
-const fetchAudioFeatures = async (songs, accessToken) => {
-    const songIds = songs.map(song => (song.uri).split(':').pop());
-    const stringOfIds = songIds.join(',');
-
-    try {
-        const response = await fetch(`https://api.spotify.com/v1/audio-features?ids=${encodeURIComponent(stringOfIds)}`, {
-            headers: {
-                'Authorization': `Bearer ${accessToken}`
-            }
-        });
-        if (!response.ok) {
-            throw new Error(`HTTP error! status: ${response.status}`);
-        }
-        const audioData = await response.json();
-        return audioData.audio_features;
-    } catch (error) {
-
-        return [];
-    }
-};
 
 function calculateGlobalFeatureAverages(features) {
     let totalValence = 0;

--- a/back-end/routes/recommendations.js
+++ b/back-end/routes/recommendations.js
@@ -34,7 +34,7 @@ const fetchAudioFeatures = async (songs, accessToken) => {
         const audioData = await response.json();
         return audioData.audio_features;
     } catch (error) {
-        console.error(error);
+
         return [];
     }
 };
@@ -106,29 +106,25 @@ function getTonalityScore(lastSongFeatures, currentSongFeatures) {
     return 0;
 }
 
-function gradingAlgorithm(lastSongFeatures, recommendationAudioFeatures, stitchAverages, moodWeight, danceWeight, mixWeight) {
-    try {
-        const scores = new Map();
-        recommendationAudioFeatures.forEach(feature => {
-            const recommendId = feature.uri.split(':').pop();
-            const valenceScore = 1 - Math.abs(stitchAverages.valence - feature.valence) / stitchAverages.valence;
-            const energyScore = 1 - Math.abs(stitchAverages.energy - feature.energy) / stitchAverages.energy;
-            const instrumentScore = 1 - Math.abs(stitchAverages.instrumentalness - feature.instrumentalness) / stitchAverages.instrumentalness;
-            const totalMoodScore = (valenceScore + energyScore + instrumentScore) / 3;
-            const danceScore = feature.danceability;
-            const tempoScore = 1 - Math.abs(lastSongFeatures.tempo - feature.tempo) / lastSongFeatures.tempo;
-            const toneScore = getTonalityScore(lastSongFeatures, feature);
-            const totalMixScore = (tempoScore + toneScore) / 2;
-            const totalScore = (totalMoodScore * moodWeight) + (danceScore * danceWeight) + (totalMixScore * mixWeight)
-            scores.set(recommendId, totalScore);
-        });
+function calculateAndSortScores(lastSongFeatures, recommendationAudioFeatures, stitchAverages, moodWeight, danceWeight, mixWeight) {
+    const scores = new Map();
+    recommendationAudioFeatures.forEach(feature => {
+        const recommendId = feature.uri.split(':').pop();
+        const valenceScore = 1 - Math.abs(stitchAverages.valence - feature.valence) / stitchAverages.valence;
+        const energyScore = 1 - Math.abs(stitchAverages.energy - feature.energy) / stitchAverages.energy;
+        const instrumentScore = 1 - Math.abs(stitchAverages.instrumentalness - feature.instrumentalness) / stitchAverages.instrumentalness;
+        const totalMoodScore = (valenceScore + energyScore + instrumentScore) / 3;
+        const danceScore = feature.danceability;
+        const tempoScore = 1 - Math.abs(lastSongFeatures.tempo - feature.tempo) / lastSongFeatures.tempo;
+        const toneScore = getTonalityScore(lastSongFeatures, feature);
+        const totalMixScore = (tempoScore + toneScore) / 2;
+        const totalScore = (totalMoodScore * moodWeight) + (danceScore * danceWeight) + (totalMixScore * mixWeight)
+        scores.set(recommendId, totalScore);
+    });
 
-        const sortedScores = Array.from(scores).sort((a, b) => b[1] - a[1]);
-        const sortedIds = sortedScores.map(entry => entry[0]);
-        return sortedIds;
-    } catch (error) {
-        console.error("Error in gradingAlgorithm:", error);
-    }
+    const sortedScores = Array.from(scores).sort((a, b) => b[1] - a[1]);
+    const sortedIds = sortedScores.map(entry => entry[0]);
+    return sortedIds;
 }
 
 const fetchRecommendations = async (songs, accessToken, exploreWeight) => {
@@ -146,7 +142,6 @@ const fetchRecommendations = async (songs, accessToken, exploreWeight) => {
         if (!response.ok) {
             if (response.status === 429) {
                 const retryAfter = response.headers.get('Retry-After');
-                console.error(`Rate limit exceeded. Retry after ${retryAfter} seconds.`);
                 return null;
             }
             throw new Error(`API request failed with status ${response.status}`);
@@ -155,7 +150,6 @@ const fetchRecommendations = async (songs, accessToken, exploreWeight) => {
         const trackRecommendations = recommendData.tracks;
         return trackRecommendations;
     } catch (error) {
-        console.error('Error fetching recommendations:', error);
         return null;
     }
 };
@@ -173,7 +167,7 @@ const fetchRankedTracks = async (songIds, accessToken) => {
         const tracks = trackData.tracks;
         return tracks;
     } catch (error) {
-        console.error(error);
+        return null;
     }
 }
 
@@ -212,7 +206,7 @@ router.get('/:stitchId', async (req, res) => {
 
         const { lastSongFeatures, stitchAverages } = await fetchAndProcessAudioFeatures(stitch.songs, accessToken);
         const recommendationAudioFeatures = await fetchAudioFeatures(recommendationTracks, accessToken);
-        const rankedRecommendationIds = gradingAlgorithm(lastSongFeatures, recommendationAudioFeatures, stitchAverages, stitch.mood, stitch.dance, stitch.mix);
+        const rankedRecommendationIds = calculateAndSortScores(lastSongFeatures, recommendationAudioFeatures, stitchAverages, stitch.mood, stitch.dance, stitch.mix);
         const userRecommendedTracks = await fetchRankedTracks(rankedRecommendationIds, accessToken);
         res.status(200).json(userRecommendedTracks);
     } catch (error) {

--- a/back-end/routes/stitchRoutes.js
+++ b/back-end/routes/stitchRoutes.js
@@ -1,5 +1,6 @@
 const express = require('express')
 const { PrismaClient } = require('@prisma/client')
+const { getAccessToken } = require('./audioFeaturesAndAccesToken');
 const router = express.Router()
 const prisma = new PrismaClient()
 
@@ -140,7 +141,7 @@ router.patch('/image', async (req, res) => {
 
 router.patch('/exportToSpotify', async (req, res) => {
     const { stitchId, username } = req.body;
-    
+    console.log(req.body)
     if (!stitchId || !username) {
         return res.status(400).json({ error: 'stitchId and username are required' });
     }
@@ -151,7 +152,11 @@ router.patch('/exportToSpotify', async (req, res) => {
                 id: parseInt(stitchId)
             },
             include: {
-                songs: true
+                songs: {
+                    orderBy: {
+                        id: 'asc'
+                    }
+                }
             }
         });
 
@@ -159,24 +164,96 @@ router.patch('/exportToSpotify', async (req, res) => {
             return res.status(404).json({ error: 'Stitch not found' });
         }
 
-        const accessToken = 'YOUR_SPOTIFY_ACCESS_TOKEN';
+        const userId = stitch.userId;
+        const accessToken = await getAccessToken(userId);
 
-        const playlistResponse = await fetch(`https://api.spotify.com/v1/users/${username}/playlists`, {
-            method: 'POST',
-            headers: {
-                'Authorization': `Bearer ${accessToken}`,
-                'Content-Type': 'application/json'
-            },
-            body: JSON.stringify({
-                name: stitch.title,
-                description: 'Created using SoundStitch',
-                public: true
-            })
-        });
+        if (!accessToken) {
+            return res.status(401).json({ error: 'Access token not found' });
+        }
 
-        res.json({ message: 'Exported to Spotify successfully', playlistId });
+        let playlistId = stitch.spotifyId;
+        if (playlistId) {
+            const updatePlaylistDetailsResponse = await fetch(`https://api.spotify.com/v1/playlists/${playlistId}`, {
+                method: 'PUT',
+                headers: {
+                    'Authorization': `Bearer ${accessToken}`,
+                    'Content-Type': 'application/json'
+                },
+                body: JSON.stringify({
+                    name: stitch.title,
+                    description: 'Created using SoundStitch' 
+                })
+            });
+
+            if (!updatePlaylistDetailsResponse.ok) {
+                throw new Error('Failed to update playlist details');
+            }
+
+            const updatePlaylistResponse = await fetch(`https://api.spotify.com/v1/playlists/${playlistId}/tracks`, {
+                method: 'PUT',
+                headers: {
+                    'Authorization': `Bearer ${accessToken}`,
+                    'Content-Type': 'application/json'
+                },
+                body: JSON.stringify({
+                    uris: stitch.songs.map(song => song.uri)
+                })
+            });
+
+            if (!updatePlaylistResponse.ok) {
+                throw new Error('Failed to update playlist tracks');
+            }
+            
+            res.json({ message: 'Updated in Spotify successfully' });
+        } else {
+            const createPlaylistResponse = await fetch(`https://api.spotify.com/v1/users/${username}/playlists`, {
+                method: 'POST',
+                headers: {
+                    'Authorization': `Bearer ${accessToken}`,
+                    'Content-Type': 'application/json'
+                },
+                body: JSON.stringify({
+                    name: stitch.title,
+                    description: 'Created using SoundStitch',
+                    public: true
+                })
+            });
+
+            const playlistData = await createPlaylistResponse.json();
+            const playlistId = playlistData.id;
+
+            if (!playlistId) {
+                throw new Error('Failed to create playlist');
+            }
+
+            await prisma.stitch.update({
+                where: {
+                    id: parseInt(stitchId)
+                },
+                data: {
+                    spotifyId: playlistId
+                }
+            });
+
+            const addTracksResponse = await fetch(`https://api.spotify.com/v1/playlists/${playlistId}/tracks`, {
+                method: 'POST',
+                headers: {
+                    'Authorization': `Bearer ${accessToken}`,
+                    'Content-Type': 'application/json'
+                },
+                body: JSON.stringify({
+                    uris: stitch.songs.map(song => song.uri)
+                })
+            });
+
+            if (!addTracksResponse.ok) {
+                throw new Error('Failed to add tracks to the playlist');
+            }
+            res.json({ message: 'Exported to Spotify successfully' });
+        }
+
     } catch (error) {
-        res.status(500).json({ error: 'Failed to export to Spotify.' });
+        res.status(500).json({ error: `Failed to export to Spotify: ${error.message}` });
     }
 });
 

--- a/back-end/routes/stitchRoutes.js
+++ b/back-end/routes/stitchRoutes.js
@@ -50,7 +50,6 @@ router.get('/title/:stitchId', async (req, res) => {
 
         res.status(200).json({ title: stitch.title });
     } catch (error) {
-        console.error('Error retrieving stitch:', error);
         res.status(500).json({ error: 'Failed to retrieve stitch.' });
     }
 });
@@ -113,7 +112,6 @@ router.patch('/title', async (req, res) => {
         });
         res.json(updatedStitch);
     } catch (error) {
-        console.error('Error updating stitch:', error);
         res.status(500).json({ error: 'Failed to update stitch.' });
     }
 });
@@ -136,7 +134,6 @@ router.patch('/image', async (req, res) => {
         });
         res.json(updatedStitch);
     } catch (error) {
-        console.error('Error updating stitch:', error);
         res.status(500).json({ error: 'Failed to update stitch.' });
     }
 });
@@ -179,7 +176,6 @@ router.patch('/exportToSpotify', async (req, res) => {
 
         res.json({ message: 'Exported to Spotify successfully', playlistId });
     } catch (error) {
-        console.error('Error exporting to Spotify:', error);
         res.status(500).json({ error: 'Failed to export to Spotify.' });
     }
 });
@@ -211,7 +207,6 @@ router.delete('/:id', async (req, res) => {
                     }
 
                 } catch (error) {
-                    console.error('Error deleting song:', error);
                     throw error;
                 }
             });
@@ -225,7 +220,6 @@ router.delete('/:id', async (req, res) => {
 
         res.status(200).json(deletedStitch);
     } catch (error) {
-        console.error('Error deleting stitch and songs:', error);
         res.status(500).json({ error: 'Failed to delete stitch and associated songs.' });
     }
 });

--- a/front-end/src/Stitch.jsx
+++ b/front-end/src/Stitch.jsx
@@ -26,16 +26,31 @@ function Stitch({ stitch, username, deleteStitch }) {
                 },
                 body: JSON.stringify({ stitchId, username })
             });
+    
+            const responseData = await response.json();
+    
+            if (!response.ok) {
+                throw new Error(responseData.error || 'Unknown error');
+            }
+    
+            toast({
+                title: "Success",
+                description: responseData.message,
+                status: "success",
+                duration: 3000,
+                isClosable: true,
+                position: "top"
+            });
+    
         } catch (error) {
             toast({
                 title: "Error",
                 description: "Failed to export stitch to Spotify",
                 status: "error",
-                duration: 5000,
+                duration: 3000,
                 isClosable: true,
                 position: "top"
             });
-            navigate('/');
         }
     };
 


### PR DESCRIPTION
**Backend**

- Moved getAccessToken and getAudioFeatures into one file so that they can then be called from clusters.js and recommendation.js and not repeat code. 
- Finished up exporting to Spotify in the backend and then added updating playlists when stitches are changed and the user tries to export again. 
- When playlists are updated: songs are added/removed how they were in SoundStitch and title's are changed as well.
- Implemented suggestions from peer mentors and manager to make code cleaner such as removing console.error's and changing function names.

**Frontend**

- Implemented toasts to show whether stitches were exported or updated successfully.

**Exporting "Grading Test" to Spotify**
<img width="1728" alt="Screenshot 2024-07-26 at 12 13 27 PM" src="https://github.com/user-attachments/assets/d106a6de-d6f4-42b3-b283-6dd5306bc5f3">

**Grading Test stitch now in my Spotify playlists**
<img width="1728" alt="Screenshot 2024-07-26 at 11 35 50 AM" src="https://github.com/user-attachments/assets/616585f5-5d1c-470d-a22f-bb978498393b">

**Added songs to Grading Test and changed name**
<img width="1728" alt="Screenshot 2024-07-26 at 1 16 41 PM" src="https://github.com/user-attachments/assets/06fbc70c-e1f4-4b8b-a6a1-a20ae2a5968d">

**Exporting again but getting updated successfully toast since stitch was previously exported**
<img width="1728" alt="Screenshot 2024-07-26 at 1 03 49 PM" src="https://github.com/user-attachments/assets/70113b3b-015a-4d68-897f-0ff4d21620fa">

**Playlist was renamed on Spotify**
<img width="1728" alt="Screenshot 2024-07-26 at 12 16 14 PM" src="https://github.com/user-attachments/assets/ab9160e1-923d-4cc1-bdf5-ed3f3e9d7886">

**Songs were added to existing Spotify playlist**
<img width="1728" alt="Screenshot 2024-07-26 at 12 16 25 PM" src="https://github.com/user-attachments/assets/bf0795f2-92da-4043-90c5-0b5ae984f9df">

