### PR TITLE
[react][node.js][prisma] Completed stretch goal where user can see and edit their stitch preferences while editing or creating their stitch. UX pull request got merged with the stitch preference pull request so UX test plan is included below.

### DIFF
--- a/back-end/prisma/migrations/20240726210655_removing_duration_from_stitches/migration.sql
+++ b/back-end/prisma/migrations/20240726210655_removing_duration_from_stitches/migration.sql
@@ -1,0 +1,8 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `duration` on the `Stitch` table. All the data in the column will be lost.
+
+*/
+-- AlterTable
+ALTER TABLE "Stitch" DROP COLUMN "duration";

--- a/back-end/prisma/migrations/20240730231329_adding_total_preferences/migration.sql
+++ b/back-end/prisma/migrations/20240730231329_adding_total_preferences/migration.sql
@@ -1,0 +1,8 @@
+/*
+  Warnings:
+
+  - Added the required column `totalPreferences` to the `Stitch` table without a default value. This is not possible if the table is not empty.
+
+*/
+-- AlterTable
+ALTER TABLE "Stitch" ADD COLUMN     "totalPreferences" DOUBLE PRECISION NOT NULL;

--- a/back-end/prisma/schema.prisma
+++ b/back-end/prisma/schema.prisma
@@ -30,18 +30,18 @@ model Token {
 }
 
 model Stitch {
-  id          Int     @id @default(autoincrement())
-  title       String
-  duration    Int
-  imageUrl    String
-  songs       Song[]
-  mood        Float
-  dance       Float
-  mix         Float
-  explore     Float
-  User        User    @relation(fields: [userId], references: [id])
+  id                Int     @id @default(autoincrement())
+  title             String
+  imageUrl          String
+  songs             Song[]
+  mood              Float
+  dance             Float
+  mix               Float
+  explore           Float
+  totalPreferences  Float
+  User        User          @relation(fields: [userId], references: [id])
   userId      Int
-  spotifyId   String? @default("")
+  spotifyId   String?       @default("")
 }
 
 model Song {

--- a/front-end/src/Create.jsx
+++ b/front-end/src/Create.jsx
@@ -1,6 +1,6 @@
 import { useParams, useLocation, useNavigate } from 'react-router-dom';
 import { useState, useEffect, useRef } from 'react';
-import { Box, Input, FormControl, Heading, Button, Text, useToast, useDisclosure } from '@chakra-ui/react';
+import { Box, Input, FormControl, Heading, Button, Text, useToast, useDisclosure, Flex, Divider, Center, Spinner } from '@chakra-ui/react';
 import Navbar from './Navbar';
 import Song from './Song';
 import CustomName from './CustomName';
@@ -17,6 +17,7 @@ function Create() {
     const [searchOptions, setSearchOptions] = useState([]);
     const [currentStitchSongs, setCurrentStitchSongs] = useState([]);
     const [recommendedSongs, setRecommendedSongs] = useState([]);
+    const [loadingRecommended, setLoadingRecommended] = useState(false);
     const [currentAudio, setCurrentAudio] = useState(null);
     const stitchId = location.state.stitchId;
     const [deleteId, setDeleteId] = useState('');
@@ -165,6 +166,7 @@ function Create() {
             return;
         }
         try {
+            setLoadingRecommended(true);
             const response = await fetch(`${import.meta.env.VITE_BACKEND_ADDRESS}/recommendation/${stitchId}`);
             const recommendedSongs = await response.json();
             setRecommendedSongs(recommendedSongs);
@@ -178,6 +180,8 @@ function Create() {
                 isClosable: true,
                 position: "top"
             });
+        } finally {
+            setLoadingRecommended(false);
         }
     }
 
@@ -239,9 +243,9 @@ function Create() {
 
     const handleToVisualization = async () => {
         await getStitchSongs();
-        if (currentStitchSongs.length <= 2) {
+        if (currentStitchSongs.length <= 3) {
             toast({
-                description: "Please have at least 3 songs in your stitch recommendations!",
+                description: "Please have at least 4 songs in your stitch before seeing visualization!",
                 status: "info",
                 duration: 3000,
                 isClosable: true,
@@ -341,149 +345,162 @@ function Create() {
                 </Box>
             </header>
             <main>
-                <Box display="flex" justifyContent="center" textAlign="center" mt="1em">
-                    <CustomName stitchId={stitchId} />
-                </Box>
-                <Box width="100%" display="flex" justifyContent="space-evenly">
-                    <Box className="searchSection" color="white" minHeight="100vh" display="flex" flexDirection="column" alignItems="center" flex="1" mt="2em">
-                        <Heading as='h3' size='xl'>Add Songs</Heading>
-                        <Box textAlign="center" mb={4}>
-                            <FormControl mt="1em">
-                                <Input
-                                    type='text'
-                                    onChange={handleSearch}
-                                    placeholder='Search for songs...'
-                                    focusBorderColor='rgb(83, 41, 140)'
-                                />
-                            </FormControl>
+                <PreferenceModal
+                    isOpen={isCreateOpen}
+                    onClose={handlePreferenceModalClose}
+                    moodValue={moodValue}
+                    setMoodValue={setMoodValue}
+                    danceValue={danceValue}
+                    setDanceValue={setDanceValue}
+                    mixValue={mixValue}
+                    setMixValue={setMixValue}
+                    exploreValue={exploreValue}
+                    setExploreValue={setExploreValue}
+                    handlePreferenceSubmit={handlePreferenceSubmit}
+                    labelStyles={labelStyles}
+                />
+
+                <Box width="100%" display="flex" justifyContent="space-evenly" my='1em'>
+                    <Box className="stitchSection" color="white" minHeight="100vh" flex="1">
+                        <Box px='2em' width='50em'>
+                            <CustomName stitchId={stitchId} />
                         </Box>
-
-                        <Box width='30em' mb='1em'>
-                            {searchOptions.slice(0, 3).map((track) => (
-                                <Song
-                                    key={track.id}
-                                    track={track}
-                                    onPlay={handleAudioPlay}
-                                    location="addSongs"
-                                    onAdd={() => handleAddSong(track)}
-                                />
-                            ))}
-                        </Box>
-
-                        <Button
-                            bgGradient="linear(to-r, rgba(115, 41, 123, 0.9), rgb(83, 41, 140, 0.9))"
-                            color="white"
-                            width="14em"
-                            _focus={{ boxShadow: 'none' }}
-                            _active={{ boxShadow: 'none' }}
-                            _hover={{
-                                opacity: 1,
-                                backgroundSize: 'auto',
-                                boxShadow: '0 0 20px -2px rgba(195, 111, 199, .5)',
-                                transform: 'translate3d(0, -0.5px, 0) scale(1.01)',
-                            }}
-                            onClick={getRecommendedSongs}
-                        >
-                            <Text fontSize="lg">Get Recommendations</Text>
-                        </Button>
-
-                        <Box width='30em' mt='1em'>
-                            {recommendedSongs.slice(0, 5).map((track) => (
-                                <Song
-                                    key={track.id}
-                                    track={track}
-                                    onPlay={handleAudioPlay}
-                                    location="addSongs"
-                                    onAdd={() => handleAddSong(track)}
-                                />
-                            ))}
-                        </Box>
-                    </Box>
-                    <Box mt="2em" display='flex' flexDirection='column' alignItems='center'>
-                        <Button
-                            className="navigateToVisualization"
-                            bgGradient="linear(to-r, rgba(115, 41, 123, 0.9), rgb(83, 41, 140, 0.9))"
-                            color="white"
-                            width="11em"
-                            mb="1em"
-                            _focus={{ boxShadow: 'none' }}
-                            _active={{ boxShadow: 'none' }}
-                            _hover={{
-                                opacity: 1,
-                                backgroundSize: 'auto',
-                                boxShadow: '0 0 20px -2px rgba(195, 111, 199, .5)',
-                                transform: 'translate3d(0, -0.5px, 0) scale(1.01)',
-                            }}
-                            onClick={handleToVisualization}
-                        >
-                            <Text fontSize="lg">View Visualization</Text>
-                        </Button>
-
-                        <Button
-                            className="navigateToVisualization"
-                            bgGradient="linear(to-r, rgba(115, 41, 123, 0.9), rgb(83, 41, 140, 0.9))"
-                            color="white"
-                            width="11em"
-                            mb="1em"
-                            _focus={{ boxShadow: 'none' }}
-                            _active={{ boxShadow: 'none' }}
-                            _hover={{
-                                opacity: 1,
-                                backgroundSize: 'auto',
-                                boxShadow: '0 0 20px -2px rgba(195, 111, 199, .5)',
-                                transform: 'translate3d(0, -0.5px, 0) scale(1.01)',
-                            }}
-                            onClick={onCreateOpen}
-                        >
-                            <Text fontSize="lg">Preferences</Text>
-                        </Button>
-
-                        <PreferenceModal
-                            isOpen={isCreateOpen}
-                            onClose={handlePreferenceModalClose}
-                            moodValue={moodValue}
-                            setMoodValue={setMoodValue}
-                            danceValue={danceValue}
-                            setDanceValue={setDanceValue}
-                            mixValue={mixValue}
-                            setMixValue={setMixValue}
-                            exploreValue={exploreValue}
-                            setExploreValue={setExploreValue}
-                            handlePreferenceSubmit={handlePreferenceSubmit}
-                            labelStyles={labelStyles}
-                        />
-
-                        <Button
-                            className="finalizeStitch"
-                            bgGradient="linear(to-r, rgba(115, 41, 123, 0.9), rgb(83, 41, 140, 0.9))"
-                            color="white"
-                            width="11em"
-                            _focus={{ boxShadow: 'none', bg: 'white', color: 'black' }}
-                            _active={{ boxShadow: 'none' }}
-                            _hover={{
-                                opacity: 1,
-                                backgroundSize: 'auto',
-                                boxShadow: '0 0 20px -2px rgba(195, 111, 199, .5)',
-                                transform: 'translate3d(0, -0.5px, 0) scale(1.01)',
-                            }}
-                            onClick={finalizeStitch}
-                        >
-                            <Text fontSize="lg">Finalize Stitch</Text>
-                        </Button>
-
-                    </Box>
-                    <Box className="stitchSection" color="white" minHeight="100vh" display="flex" flexDirection="column" alignItems="center" flex="1" mt="2em">
-                        <Heading as='h3' size='xl'>Current Stitch</Heading>
-                        <Box mt="1em" width="30em">
+                        <Flex direction="row" justifyContent="left" mt="1em" gap="0.5em" pl="2em">
+                            <Button
+                                bg="rgb(225, 225, 225)"
+                                color="black"
+                                size="sm"
+                                _focus={{ boxShadow: 'none' }}
+                                _active={{ boxShadow: 'none' }}
+                                _hover={{
+                                    boxShadow: '0 0 20px -2px rgba(255, 255, 255, 0.9)',
+                                    transform: 'translate3d(0, -0.5px, 0) scale(1.01)',
+                                }}
+                                onClick={onCreateOpen}
+                            >
+                                Preferences
+                            </Button>
+                            <Button
+                                bgGradient="linear(to-r, rgba(115, 41, 123, 0.9), rgb(83, 41, 140, 0.9))"
+                                color="white"
+                                size="sm"
+                                _focus={{ boxShadow: 'none' }}
+                                _active={{ boxShadow: 'none' }}
+                                _hover={{
+                                    opacity: 1,
+                                    backgroundSize: 'auto',
+                                    boxShadow: '0 0 20px -2px rgba(195, 111, 199, .5)',
+                                    transform: 'translate3d(0, -0.5px, 0) scale(1.01)',
+                                }}
+                                onClick={handleToVisualization}
+                            >
+                                View Visualization
+                            </Button>
+                            <Button
+                                bgGradient="linear(to-r, rgba(115, 41, 123, 0.9), rgb(83, 41, 140, 0.9))"
+                                color="white"
+                                size="sm"
+                                _focus={{ boxShadow: 'none', bg: 'white', color: 'black' }}
+                                _active={{ boxShadow: 'none' }}
+                                _hover={{
+                                    opacity: 1,
+                                    backgroundSize: 'auto',
+                                    boxShadow: '0 0 20px -2px rgba(195, 111, 199, .5)',
+                                    transform: 'translate3d(0, -0.5px, 0) scale(1.01)',
+                                }}
+                                onClick={finalizeStitch}
+                            >
+                                Finalize Stitch
+                            </Button>
+                        </Flex>
+                        <Box mt="1em" px="2em">
                             {currentStitchSongs.map((song) => (
-                                <Song
-                                    key={song.id}
-                                    track={song}
-                                    onPlay={handleAudioPlay}
-                                    location="currentStitch"
-                                    onRemove={() => handleRemove(song.id)}
-                                />
+                                <Flex justifyContent="center">
+                                    <Song
+                                        key={song.id}
+                                        track={song}
+                                        onPlay={handleAudioPlay}
+                                        location="currentStitch"
+                                        onRemove={() => handleRemove(song.id)}
+                                    />
+                                </Flex>
                             ))}
+                        </Box>
+                    </Box>
+                    <Center>
+                        <Divider orientation='vertical' />
+                    </Center>
+                    <Box className="searchSection" color="white" minHeight="100vh" flex="1">
+                        <Flex direction="row" justifyContent="space-between" alignItems="center" gap="1em" px="2em">
+                            <Box textAlign="center" mb='1em' flex='1'>
+                                <FormControl mt="1em">
+                                    <Input
+                                        type='text'
+                                        onChange={handleSearch}
+                                        placeholder='Search for songs here...'
+                                        focusBorderColor='rgb(83, 41, 140)'
+                                    />
+                                </FormControl>
+                            </Box>
+                            <Button
+                                bgGradient="linear(to-r, rgba(115, 41, 123, 0.9), rgb(83, 41, 140, 0.9))"
+                                color="white"
+                                size="sm"
+                                _focus={{ boxShadow: 'none' }}
+                                _active={{ boxShadow: 'none' }}
+                                _hover={{
+                                    opacity: 1,
+                                    backgroundSize: 'auto',
+                                    boxShadow: '0 0 20px -2px rgba(195, 111, 199, .5)',
+                                    transform: 'translate3d(0, -0.5px, 0) scale(1.01)',
+                                }}
+                                onClick={getRecommendedSongs}
+                            >
+                                Get Recommendations
+                            </Button>
+                        </Flex>
+                        <Box px='2em'>
+                            {searchOptions.slice(0, 3).map((track) => (
+                                <Flex justifyContent="center">
+                                    <Song
+                                        key={track.id}
+                                        track={track}
+                                        onPlay={handleAudioPlay}
+                                        location="addSongs"
+                                        onAdd={() => handleAddSong(track)}
+                                    />
+                                </Flex>
+                            ))}
+                        </Box>
+
+                        <Box px='2em' mt='1em'>
+                            {loadingRecommended ? (
+                                <>
+                                    <Text mb='1em' fontWeight='bold'>Recommended Songs</Text>
+                                    <Center>
+                                        <Spinner size='xl' color='rgb(83, 41, 140)' emptyColor='gray.200' />
+                                    </Center>
+                                </>
+                            ) : (
+                                <>
+                                    {recommendedSongs.length > 0 && (
+                                        <>
+                                            <Text mb='1em' fontWeight='bold'>Recommended Songs</Text>
+                                            {recommendedSongs.slice(0, 5).map((track) => (
+                                                <Flex justifyContent="center">
+                                                    <Song
+                                                        key={track.id}
+                                                        track={track}
+                                                        onPlay={handleAudioPlay}
+                                                        location="addSongs"
+                                                        onAdd={() => handleAddSong(track)}
+                                                    />
+                                                </Flex>
+                                            ))}
+                                        </>
+                                    )}
+                                </>
+                            )}
                         </Box>
                     </Box>
                 </Box>

--- a/front-end/src/CustomName.jsx
+++ b/front-end/src/CustomName.jsx
@@ -2,30 +2,20 @@ import {
     Editable,
     EditableInput,
     EditablePreview,
-    useEditableControls,
-    ButtonGroup,
-    IconButton,
     Flex,
-    Input,
-    Box,
     useToast
 } from '@chakra-ui/react';
-import { CheckIcon, CloseIcon, EditIcon } from '@chakra-ui/icons';
 import { useState, useEffect } from 'react';
 
 const CustomName = ({ stitchId }) => {
     const [title, setTitle] = useState('Untitled');
-    const [revTitle, setRevTitle] = useState('Untitled');
     const toast = useToast();
 
-    const handleChange = (event) => {
-        setTitle(event.target.value);
-    };
-
     const handleSubmit = async () => {
+        let newTitle = title;
         if (!title) {
             setTitle('Untitled');
-            return;
+            newTitle = 'Untitled';
         }
 
         try {
@@ -34,14 +24,12 @@ const CustomName = ({ stitchId }) => {
                 headers: {
                     'Content-Type': 'application/json',
                 },
-                body: JSON.stringify({ stitchId, title }),
+                body: JSON.stringify({ stitchId, title: newTitle }),
             });
 
             if (!response.ok) {
                 throw new Error('Failed to update stitch name');
             }
-
-            setRevTitle(title);
         } catch (error) {
             toast({
                 title: "Error",
@@ -52,10 +40,6 @@ const CustomName = ({ stitchId }) => {
                 position: "top"
             });
         }
-    };
-
-    const handleAbort = () => {
-        setTitle(revTitle);
     };
 
     useEffect(() => {
@@ -70,7 +54,6 @@ const CustomName = ({ stitchId }) => {
 
                 const data = await response.json();
                 setTitle(data.title || 'Untitled');
-                setRevTitle(data.title || 'Untitled');
             } catch (error) {
                 toast({
                     title: "Error",
@@ -84,45 +67,39 @@ const CustomName = ({ stitchId }) => {
         };
 
         fetchStitchName();
-    }, [stitchId]);
-
-    const EditableControls = () => {
-        const {
-            isEditing,
-            getSubmitButtonProps,
-            getCancelButtonProps,
-            getEditButtonProps,
-        } = useEditableControls();
-
-        return isEditing ? (
-            <ButtonGroup justifyContent='center' size='sm'>
-                <IconButton icon={<CheckIcon />} {...getSubmitButtonProps()} />
-                <IconButton icon={<CloseIcon />} {...getCancelButtonProps()} />
-            </ButtonGroup>
-        ) : (
-            <Flex justifyContent='center'>
-                <IconButton size='sm' onClick={() => setRevTitle(title)} icon={<EditIcon />} {...getEditButtonProps()} />
-            </Flex>
-        );
-    };
+    }, [stitchId, toast]);
 
     return (
-        <Box width="40em">
+        <Flex align='left' width='auto'>
             <Editable
-                textAlign='center'
-                fontSize='4xl'
+                textAlign='left'
+                fontSize='6xl'
                 fontWeight='bold'
                 color='white'
                 value={title}
-                isPreviewFocusable={false}
+                onChange={(nextValue) => setTitle(nextValue)}
+                isPreviewFocusable={true}
                 onSubmit={handleSubmit}
-                onCancel={handleAbort}
+                submitOnBlur={true}
+                width='100%'
             >
-                <EditablePreview />
-                <Input as={EditableInput} focusBorderColor='rgb(83, 41, 140)' fontSize='3xl' onChange={handleChange}/>
-                <EditableControls />
+                <EditablePreview
+                    _hover={{
+                        cursor: 'pointer'
+                    }}
+                    whiteSpace="normal"
+                    overflow="visible"
+                    textOverflow="clip"
+                    width="100%"
+                />
+                <EditableInput
+                    fontSize='6xl'
+                    _focus={{
+                        boxShadow: '0 0 0 3px rgb(83, 41, 140)',
+                    }}
+                />
             </Editable>
-        </Box>
+        </Flex >
     );
 };
 

--- a/front-end/src/Navbar.jsx
+++ b/front-end/src/Navbar.jsx
@@ -1,6 +1,7 @@
 import { useNavigate } from 'react-router-dom';
 import { useState, useEffect } from 'react';
 import noImage from './assets/Image_not_available.png';
+import PreferenceModal from './PreferenceModal';
 import {
     Box,
     Flex,
@@ -18,14 +19,7 @@ import {
     ModalHeader,
     ModalCloseButton,
     ModalBody,
-    ModalFooter,
     useDisclosure,
-    Slider,
-    SliderMark,
-    SliderTrack,
-    SliderFilledTrack,
-    Tooltip,
-    SliderThumb,
     SimpleGrid,
     Image,
     useToast
@@ -40,10 +34,6 @@ function Navbar({ username, page }) {
     const [danceValue, setDanceValue] = useState(50);
     const [mixValue, setMixValue] = useState(50);
     const [exploreValue, setExploreValue] = useState(50);
-    const [showMoodValue, setShowMood] = useState(false);
-    const [showDanceValue, setShowDance] = useState(false);
-    const [showMixValue, setShowMix] = useState(false);
-    const [showExploreValue, setShowExplore] = useState(false);
     const [profileData, setProfileData] = useState(null);
     const [userTopTracks, setUserTopTracks] = useState(null);
     const toast = useToast();
@@ -161,10 +151,10 @@ function Navbar({ username, page }) {
                 body: JSON.stringify({
                     title: 'Untitled',
                     username,
-                    mood: values.moodValue / 100,
-                    dance: values.danceValue / 100,
-                    mix: values.mixValue / 100,
-                    explore: values.exploreValue / 100,
+                    mood: values.moodValue,
+                    dance: values.danceValue,
+                    mix: values.mixValue,
+                    explore: values.exploreValue,
                     imageUrl: noImage
                 })
             });
@@ -181,7 +171,6 @@ function Navbar({ username, page }) {
             });
         }
     };
-
 
     const handleLogout = () => {
         try {
@@ -329,146 +318,20 @@ function Navbar({ username, page }) {
                             <Text fontSize="lg">Create Stitch</Text>
                         </MenuItem>
 
-                        <Modal size="xl" onClose={handlePreferenceModalClose} isOpen={isCreateOpen} motionPreset='slideInBottom' isCentered>
-                            <ModalOverlay backdropFilter='auto' backdropBlur='2px' />
-                            <ModalContent>
-                                <ModalHeader textAlign="center">
-                                    <Heading color='black'>Stitch Preferences</Heading>
-                                    <Text color='gray.700' fontSize='sm' mt='1.5em'>Answer the following questions so we can give you personalized recommendations!</Text>
-                                </ModalHeader>
-                                <ModalCloseButton />
-                                <ModalBody textAlign="center">
-                                    <Text color='black' as='b'>Mood</Text>
-                                    <Box p={2} pt={7} mb='1em'>
-                                        <Slider aria-label='slider-ex-6'
-                                            onChange={(val) => setMoodValue(val)}
-                                            onMouseEnter={() => setShowMood(true)}
-                                            onMouseLeave={() => setShowMood(false)}>
-                                            <SliderMark value={25} {...labelStyles}>
-                                                25%
-                                            </SliderMark>
-                                            <SliderMark value={50} {...labelStyles}>
-                                                50%
-                                            </SliderMark>
-                                            <SliderMark value={75} {...labelStyles}>
-                                                75%
-                                            </SliderMark>
-                                            <SliderTrack>
-                                                <SliderFilledTrack sx={{ bgColor: 'rgb(83, 41, 140)' }} />
-                                            </SliderTrack>
-                                            <Tooltip
-                                                hasArrow
-                                                bg='rgb(83, 41, 140)'
-                                                color='white'
-                                                placement='top'
-                                                isOpen={showMoodValue}
-                                                label={`${moodValue}%`}
-                                            >
-                                                <SliderThumb />
-                                            </Tooltip>
-                                        </Slider>
-                                        <Text color='gray.700' fontSize='sm' mt='1.5em'>How important is consistent mood in your stitch? 100% = consistent 🙂.</Text>
-                                    </Box>
-                                    <Text color='black' as='b'>Danceability</Text>
-                                    <Box p={2} pt={7} mb='1em'>
-                                        <Slider aria-label='slider-ex-6'
-                                            onChange={(val) => setDanceValue(val)}
-                                            onMouseEnter={() => setShowDance(true)}
-                                            onMouseLeave={() => setShowDance(false)}>
-                                            <SliderMark value={25} {...labelStyles}>
-                                                25%
-                                            </SliderMark>
-                                            <SliderMark value={50} {...labelStyles}>
-                                                50%
-                                            </SliderMark>
-                                            <SliderMark value={75} {...labelStyles}>
-                                                75%
-                                            </SliderMark>
-                                            <SliderTrack>
-                                                <SliderFilledTrack sx={{ bgColor: 'rgb(83, 41, 140)' }} />
-                                            </SliderTrack>
-                                            <Tooltip
-                                                hasArrow
-                                                bg='rgb(83, 41, 140)'
-                                                color='white'
-                                                placement='top'
-                                                isOpen={showDanceValue}
-                                                label={`${danceValue}%`}
-                                            >
-                                                <SliderThumb />
-                                            </Tooltip>
-                                        </Slider>
-                                        <Text color='gray.700' fontSize='sm' mt='1.5em'>How important is dancing in your stitch? 100% = dance party 🕺.</Text>
-                                    </Box>
-                                    <Text color='black' as='b'>Mixability</Text>
-                                    <Box p={2} pt={7} mb='1em'>
-                                        <Slider aria-label='slider-ex-6'
-                                            onChange={(val) => setMixValue(val)}
-                                            onMouseEnter={() => setShowMix(true)}
-                                            onMouseLeave={() => setShowMix(false)}>
-                                            <SliderMark value={25} {...labelStyles}>
-                                                25%
-                                            </SliderMark>
-                                            <SliderMark value={50} {...labelStyles}>
-                                                50%
-                                            </SliderMark>
-                                            <SliderMark value={75} {...labelStyles}>
-                                                75%
-                                            </SliderMark>
-                                            <SliderTrack>
-                                                <SliderFilledTrack sx={{ bgColor: 'rgb(83, 41, 140)' }} />
-                                            </SliderTrack>
-                                            <Tooltip
-                                                hasArrow
-                                                bg='rgb(83, 41, 140)'
-                                                color='white'
-                                                placement='top'
-                                                isOpen={showMixValue}
-                                                label={`${mixValue}%`}
-                                            >
-                                                <SliderThumb />
-                                            </Tooltip>
-                                        </Slider>
-                                        <Text color='gray.700' fontSize='sm' mt='1.5em'>How important is the mixability of your stitch? 100% = DJ level 🎧.</Text>
-                                    </Box>
-                                    <Text color='black' as='b'>Explore</Text>
-                                    <Box p={2} pt={7}>
-                                        <Slider aria-label='slider-ex-6'
-                                            onChange={(val) => setExploreValue(val)}
-                                            onMouseEnter={() => setShowExplore(true)}
-                                            onMouseLeave={() => setShowExplore(false)}>
-                                            <SliderMark value={25} {...labelStyles}>
-                                                25%
-                                            </SliderMark>
-                                            <SliderMark value={50} {...labelStyles}>
-                                                50%
-                                            </SliderMark>
-                                            <SliderMark value={75} {...labelStyles}>
-                                                75%
-                                            </SliderMark>
-                                            <SliderTrack>
-                                                <SliderFilledTrack sx={{ bgColor: 'rgb(83, 41, 140)' }} />
-                                            </SliderTrack>
-                                            <Tooltip
-                                                hasArrow
-                                                bg='rgb(83, 41, 140)'
-                                                color='white'
-                                                placement='top'
-                                                isOpen={showExploreValue}
-                                                label={`${exploreValue}%`}
-                                            >
-                                                <SliderThumb />
-                                            </Tooltip>
-                                        </Slider>
-                                        <Text color='gray.700' fontSize='sm' mt='1.5em'>How important is finding music you haven't listened to? 100% = explorer 🧭.</Text>
-                                    </Box>
-                                </ModalBody>
-                                <ModalFooter display="flex" justifyContent="center">
-                                    <Button onClick={handlePreferenceSubmit}>Submit</Button>
-                                    <Button onClick={handlePreferenceModalClose} ml={3}>Close</Button>
-                                </ModalFooter>
-                            </ModalContent>
-                        </Modal>
+                        <PreferenceModal
+                            isOpen={isCreateOpen}
+                            onClose={handlePreferenceModalClose}
+                            moodValue={moodValue}
+                            setMoodValue={setMoodValue}
+                            danceValue={danceValue}
+                            setDanceValue={setDanceValue}
+                            mixValue={mixValue}
+                            setMixValue={setMixValue}
+                            exploreValue={exploreValue}
+                            setExploreValue={setExploreValue}
+                            handlePreferenceSubmit={handlePreferenceSubmit}
+                            labelStyles={labelStyles}
+                        />
 
                         <MenuItem
                             style={{ margin: 0 }}

--- a/front-end/src/Navbar.jsx
+++ b/front-end/src/Navbar.jsx
@@ -100,7 +100,7 @@ function Navbar({ username, page }) {
         }
 
         try {
-            const response = await fetch(`https://api.spotify.com/v1/me/top/tracks`, {
+            const response = await fetch(`https://api.spotify.com/v1/me/top/tracks?time_range=short_term`, {
                 headers: {
                     'Authorization': `Bearer ${accessToken}`
                 }

--- a/front-end/src/PreferenceModal.jsx
+++ b/front-end/src/PreferenceModal.jsx
@@ -1,0 +1,188 @@
+import { useState } from "react";
+import {
+    Modal,
+    ModalOverlay,
+    ModalContent,
+    ModalHeader,
+    ModalFooter,
+    ModalBody,
+    ModalCloseButton,
+    Button,
+    Box,
+    Heading,
+    Text,
+    Slider,
+    SliderMark,
+    SliderTrack,
+    SliderFilledTrack,
+    SliderThumb,
+    Tooltip
+} from "@chakra-ui/react";
+
+const PreferenceModal = ({
+    isOpen,
+    onClose,
+    moodValue,
+    setMoodValue,
+    danceValue,
+    setDanceValue,
+    mixValue,
+    setMixValue,
+    exploreValue,
+    setExploreValue,
+    handlePreferenceSubmit,
+    labelStyles
+}) => {
+    const [showMoodValue, setShowMood] = useState(false);
+    const [showDanceValue, setShowDance] = useState(false);
+    const [showMixValue, setShowMix] = useState(false);
+    const [showExploreValue, setShowExplore] = useState(false);
+
+    return (
+        <Modal size="xl" onClose={onClose} isOpen={isOpen} motionPreset='slideInBottom' isCentered>
+            <ModalOverlay backdropFilter='auto' backdropBlur='2px' />
+            <ModalContent>
+                <ModalHeader textAlign="center">
+                    <Heading color='black'>Stitch Preferences</Heading>
+                    <Text color='gray.700' fontSize='sm' mt='1.5em'>Answer the following questions so we can give you personalized recommendations!</Text>
+                </ModalHeader>
+                <ModalCloseButton />
+                <ModalBody textAlign="center">
+                    <Text color='black' as='b'>Mood</Text>
+                    <Box p={2} pt={7} mb='1em'>
+                        <Slider aria-label='slider-ex-6'
+                            value={moodValue}
+                            onChange={(val) => setMoodValue(val)}
+                            onMouseEnter={() => setShowMood(true)}
+                            onMouseLeave={() => setShowMood(false)}>
+                            <SliderMark value={25} {...labelStyles}>
+                                25%
+                            </SliderMark>
+                            <SliderMark value={50} {...labelStyles}>
+                                50%
+                            </SliderMark>
+                            <SliderMark value={75} {...labelStyles}>
+                                75%
+                            </SliderMark>
+                            <SliderTrack>
+                                <SliderFilledTrack sx={{ bgColor: 'rgb(83, 41, 140)' }} />
+                            </SliderTrack>
+                            <Tooltip
+                                hasArrow
+                                bg='rgb(83, 41, 140)'
+                                color='white'
+                                placement='top'
+                                isOpen={showMoodValue}
+                                label={`${moodValue}%`}
+                            >
+                                <SliderThumb />
+                            </Tooltip>
+                        </Slider>
+                        <Text color='gray.700' fontSize='sm' mt='1.5em'>How important is consistent mood in your stitch? 100% = consistent 🙂.</Text>
+                    </Box>
+                    <Text color='black' as='b'>Danceability</Text>
+                    <Box p={2} pt={7} mb='1em'>
+                        <Slider aria-label='slider-ex-6'
+                            value={danceValue}
+                            onChange={(val) => setDanceValue(val)}
+                            onMouseEnter={() => setShowDance(true)}
+                            onMouseLeave={() => setShowDance(false)}>
+                            <SliderMark value={25} {...labelStyles}>
+                                25%
+                            </SliderMark>
+                            <SliderMark value={50} {...labelStyles}>
+                                50%
+                            </SliderMark>
+                            <SliderMark value={75} {...labelStyles}>
+                                75%
+                            </SliderMark>
+                            <SliderTrack>
+                                <SliderFilledTrack sx={{ bgColor: 'rgb(83, 41, 140)' }} />
+                            </SliderTrack>
+                            <Tooltip
+                                hasArrow
+                                bg='rgb(83, 41, 140)'
+                                color='white'
+                                placement='top'
+                                isOpen={showDanceValue}
+                                label={`${danceValue}%`}
+                            >
+                                <SliderThumb />
+                            </Tooltip>
+                        </Slider>
+                        <Text color='gray.700' fontSize='sm' mt='1.5em'>How important is dancing in your stitch? 100% = dance party 🕺.</Text>
+                    </Box>
+                    <Text color='black' as='b'>Mixability</Text>
+                    <Box p={2} pt={7} mb='1em'>
+                        <Slider aria-label='slider-ex-6'
+                            value={mixValue}
+                            onChange={(val) => setMixValue(val)}
+                            onMouseEnter={() => setShowMix(true)}
+                            onMouseLeave={() => setShowMix(false)}>
+                            <SliderMark value={25} {...labelStyles}>
+                                25%
+                            </SliderMark>
+                            <SliderMark value={50} {...labelStyles}>
+                                50%
+                            </SliderMark>
+                            <SliderMark value={75} {...labelStyles}>
+                                75%
+                            </SliderMark>
+                            <SliderTrack>
+                                <SliderFilledTrack sx={{ bgColor: 'rgb(83, 41, 140)' }} />
+                            </SliderTrack>
+                            <Tooltip
+                                hasArrow
+                                bg='rgb(83, 41, 140)'
+                                color='white'
+                                placement='top'
+                                isOpen={showMixValue}
+                                label={`${mixValue}%`}
+                            >
+                                <SliderThumb />
+                            </Tooltip>
+                        </Slider>
+                        <Text color='gray.700' fontSize='sm' mt='1.5em'>How important is the mixability of your stitch? 100% = DJ level 🎧.</Text>
+                    </Box>
+                    <Text color='black' as='b'>Explore</Text>
+                    <Box p={2} pt={7}>
+                        <Slider aria-label='slider-ex-6'
+                            value={exploreValue}
+                            onChange={(val) => setExploreValue(val)}
+                            onMouseEnter={() => setShowExplore(true)}
+                            onMouseLeave={() => setShowExplore(false)}>
+                            <SliderMark value={25} {...labelStyles}>
+                                25%
+                            </SliderMark>
+                            <SliderMark value={50} {...labelStyles}>
+                                50%
+                            </SliderMark>
+                            <SliderMark value={75} {...labelStyles}>
+                                75%
+                            </SliderMark>
+                            <SliderTrack>
+                                <SliderFilledTrack sx={{ bgColor: 'rgb(83, 41, 140)' }} />
+                            </SliderTrack>
+                            <Tooltip
+                                hasArrow
+                                bg='rgb(83, 41, 140)'
+                                color='white'
+                                placement='top'
+                                isOpen={showExploreValue}
+                                label={`${exploreValue}%`}
+                            >
+                                <SliderThumb />
+                            </Tooltip>
+                        </Slider>
+                        <Text color='gray.700' fontSize='sm' mt='1.5em'>How important is finding music you haven't listened to? 100% = explorer 🧭.</Text>
+                    </Box>
+                </ModalBody>
+                <ModalFooter display="flex" justifyContent="center">
+                    <Button onClick={handlePreferenceSubmit}>Submit</Button>
+                </ModalFooter>
+            </ModalContent>
+        </Modal>
+    );
+};
+
+export default PreferenceModal;

--- a/front-end/src/Song.css
+++ b/front-end/src/Song.css
@@ -1,49 +1,8 @@
 #song {
     transition: all 0.3s ease;
-    display: flex;
-    background-color: rgba(225, 225, 225, 0.8);
-    border-radius: 10px;
-    padding: 10px;
-    margin-bottom: 0.5em;
-    width: 100%; 
-    max-width: 600px; 
 }
 
 #song:hover {
-    background-color: rgb(225, 225, 225);
     transform: translate3d(0, -2px, 0) scale(1.03);
     transition: all 0.3s ease;
-}
-
-.songImage {
-    width: 4em;
-    height: 3em;
-}
-
-#songName,
-#artist,
-#album {
-    white-space: nowrap; 
-    overflow: hidden; 
-    text-overflow: ellipsis; 
-    max-width: 70%; 
-}
-
-#songName {
-    font-size: 0.8em;
-    margin-bottom: 0.2em;
-    margin-top: 0.1em;
-}
-
-#artist,
-#album {
-    font-size: 0.6em;
-    margin-top: 0.2em;
-    margin-bottom: 0.2em;
-}
-
-#duration {
-    margin-left: auto;
-    text-align: right;
-    font-size: 0.6em;
 }

--- a/front-end/src/Song.jsx
+++ b/front-end/src/Song.jsx
@@ -26,20 +26,19 @@ function Song({ track, onPlay, location, onAdd, onRemove }) {
             borderRadius="10px"
             p="10px"
             mb="0.5em"
+            color="black"
             onMouseEnter={() => setIsHovered(true)}
             onMouseLeave={() => setIsHovered(false)}
             _hover={{
                 backgroundColor: 'rgb(225, 225, 225)',
                 transform: 'translate3d(0, -2px, 0) scale(1.03)',
                 transition: 'all 0.3s ease',
-                color: 'black',
                 cursor: 'pointer'
             }}
             width="100%"
-            maxWidth="600px"
         >
-            <Image className="songImage" src={album.images[0].url} alt="Song Image" width="4em" height="3em" />
-            <Box id="songDetails" ml="1em">
+            <Image className="songImage" src={album.images[0].url} alt="Song Image" width="3em" height="3em" />
+            <Box id="songDetails" ml="1em" >
                 <Text
                     id="songName"
                     fontSize="0.8em"
@@ -48,7 +47,7 @@ function Song({ track, onPlay, location, onAdd, onRemove }) {
                     whiteSpace="nowrap"
                     overflow="hidden"
                     textOverflow="ellipsis"
-                    width="10em"
+                    width="18em"
                 >
                     {name}
                 </Text>
@@ -60,7 +59,7 @@ function Song({ track, onPlay, location, onAdd, onRemove }) {
                     whiteSpace="nowrap"
                     overflow="hidden"
                     textOverflow="ellipsis"
-                    width="10em"
+                    width="18em"
                 >
                     {artists.map(artist => artist.name).join(', ')}
                 </Text>
@@ -71,31 +70,31 @@ function Song({ track, onPlay, location, onAdd, onRemove }) {
                     whiteSpace="nowrap"
                     overflow="hidden"
                     textOverflow="ellipsis"
-                    width="10em"
+                    width="18em"
                 >
                     {album.name}
                 </Text>
             </Box>
-            <Box ml="auto" textAlign="center" display="flex" alignItems="center" position="relative">
-                <Box mr={2}>
+            <Box ml="6em" textAlign="center" display="flex" alignItems="center" position="relative">
+                <Box mr="2em">
                     {preview_url ? (
-                        <audio ref={audioRef} controls style={{ width: '15em' }} onPlay={handleAudioPlay}>
+                        <audio ref={audioRef} controls style={{ width: '20em' }} onPlay={handleAudioPlay}>
                             <source src={preview_url} type="audio/mpeg" />
                         </audio>
                     ) : (
-                        <Box width="15em">
-                            <Text id="duration" fontSize="0.6em" mr={3}>Audio not available</Text>
+                        <Box width="20em">
+                            <Text id="duration" fontSize="0.6em">Audio not available</Text>
                         </Box>
                     )}
                 </Box>
                 <Text id="duration" fontSize="0.6em">{duration}</Text>
-                {isHovered && (
-                    <IconButton
+            </Box>
+            {isHovered && (
+                    <IconButton pos="absolute" right="-0.7em"
                         icon={location === 'addSongs' ? <AddIcon /> : <MinusIcon />}
                         onClick={location === 'addSongs' ? onAdd : onRemove}
                     />
                 )}
-            </Box>
         </Box>
     );
 }

--- a/front-end/src/visualization/Visualization.jsx
+++ b/front-end/src/visualization/Visualization.jsx
@@ -61,7 +61,7 @@ function Visualization() {
     function calculateClusterPositions(count, centerX, centerY, radius) {
         const positions = [];
         for (let i = 0; i < count; i++) {
-            const angle = ((i / count) * 2 * Math.PI) - Math.PI / 2;
+            const angle = ((i / count) * 2 * Math.PI);
             const x = centerX + radius * Math.cos(angle);
             const y = centerY + radius * Math.sin(angle);
             positions.push({ x, y });
@@ -294,8 +294,6 @@ function Visualization() {
                             _focus={{ boxShadow: 'none', bg: 'white', color: 'black' }}
                             _active={{ boxShadow: 'none' }}
                             _hover={{
-                                opacity: 1,
-                                backgroundSize: 'auto',
                                 boxShadow: '0 0 20px -2px rgba(195, 111, 199, .5)',
                                 transform: 'translate3d(0, -0.5px, 0) scale(1.01)',
                             }}


### PR DESCRIPTION
**Preference Modal Stretch Goal Test Plan**

**Database**

- Changed database model of stitch to no longer hold duration since it is not used. 
- Additionally, now stitch model holds totalPreferences which is used to convert the weighted values that are saved in the database into what values the user actually chose using the sliders. 

**Backend**
 
- Revised how I was creating stitch to now save the total preferences. 
- Also added the patch method that updates the database upon the user submitting the preference modal. 

**Frontend**
- Created a PreferenceModal component and moved my modal into that so it could be reused more easily in the Create component. 
- Implemented calls and created a button in Create to open modal and use refs/useStates to make changes as well as save the original values in case the user doesn't press submit.


**Image of preference modal with values of preferences already determined by the user**

<img width="1728" alt="Screenshot 2024-07-30 at 5 56 05 PM" src="https://github.com/user-attachments/assets/f2db2500-dba5-4d60-aa08-0ff0fd80e683">



**UX improvements Test Plan**

- Improved UX in create/edit page by taking up white space and putting buttons into button groups. 
- Revised the CustomName component to no longer use controls and be editable on click and changes the name of the stitch if the user presses enter or clicks somewhere on the screen. 
- If the user leaves the stitch name empty, it is automatically saved as Untitled. 
- Added loading state while recommendations are being fetched from the backend. 
- Adjusted song containers to take up almost half of the screen and adjusted the song component accordingly for the new size.
- Added divider in between different sections

**What the create page used to look like**

<img width="1728" alt="Screenshot 2024-07-26 at 1 32 21 PM" src="https://github.com/user-attachments/assets/fee6a620-908b-453f-95aa-1956703b9744">

**What it looks like now with all the changes implemented**

1.) No search results or recommendations showing.

<img width="1728" alt="Screenshot 2024-07-31 at 5 15 14 PM" src="https://github.com/user-attachments/assets/707174db-6412-44bb-8975-e8ecbe935e0d">

2.) Only recommended songs being displayed.

<img width="1728" alt="Screenshot 2024-07-31 at 5 15 51 PM" src="https://github.com/user-attachments/assets/c65e512a-6da4-4740-98c3-c4a519957d83">

3.) Search results with recommended songs displayed.

<img width="1728" alt="Screenshot 2024-07-31 at 5 10 54 PM" src="https://github.com/user-attachments/assets/2bb89b50-e8fb-4a7f-924e-13f3f97ff3fa">

**Below I have examples of how the recommendation loading looks with different items being shown before pressing recommendation button**


https://github.com/user-attachments/assets/ba115b95-fb07-41f2-b177-92b552e11498


https://github.com/user-attachments/assets/bc021519-a63e-4089-9a7d-9c45a2060595


https://github.com/user-attachments/assets/d5bd39e8-723a-41c9-9e7d-08ee2b3d0e05


**Demonstration of improved name changing**

https://github.com/user-attachments/assets/ccc8cdf8-f7a4-40e0-a049-de148b26999e
