### PR TITLE
[react] UX improvements and stretch goal finished for draft state.

### DIFF
--- a/front-end/index.html
+++ b/front-end/index.html
@@ -1,12 +1,21 @@
 <!doctype html>
 <html lang="en">
-  <head>
-    <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>SoundStitch</title>
-  </head>
-  <body>
-    <div id="root"></div>
-    <script type="module" src="/src/main.jsx"></script>
-  </body>
+
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Raleway:ital,wght@0,100..900;1,100..900&display=swap"
+    rel="stylesheet">
+
+  <title>SoundStitch</title>
+</head>
+
+<body>
+  <div id="root"></div>
+  <script type="module" src="/src/main.jsx"></script>
+</body>
+
 </html>

--- a/front-end/src/App.jsx
+++ b/front-end/src/App.jsx
@@ -13,7 +13,8 @@ function App() {
           <Route path='/' element={<SpotifyLogin />} />
           <Route path='/auth/callback' element={<SpotifyCallback />} />
           <Route path='/:username' element={<Home />} />
-          <Route path='/:username/create' element={<Create />} />
+          <Route path='/:username/:action' element={<Create />} />
+          {/* <Route path='/:username/edit' element={<Create />} /> */}
           <Route path='/:username/visualization' element={<Visualization />} />
         </Routes>
       </div>

--- a/front-end/src/Create.jsx
+++ b/front-end/src/Create.jsx
@@ -14,6 +14,7 @@ function Create() {
     const toast = useToast();
     const navigate = useNavigate();
     const username = params.username;
+    const action = params.action;
     const [searchOptions, setSearchOptions] = useState([]);
     const [currentStitchSongs, setCurrentStitchSongs] = useState([]);
     const [recommendedSongs, setRecommendedSongs] = useState([]);
@@ -31,6 +32,14 @@ function Create() {
     const [danceValue, setDanceValue] = useState();
     const [mixValue, setMixValue] = useState();
     const [exploreValue, setExploreValue] = useState();
+
+    const handleMouseEnter = () => {
+        document.body.style.overflow = 'hidden';
+    };
+
+    const handleMouseLeave = () => {
+        document.body.style.overflow = 'auto';
+    };
 
     const labelStyles = {
         mt: '2',
@@ -129,6 +138,14 @@ function Create() {
                 .then(data => {
                     getStitchSongs();
                 })
+            toast.closeAll()
+            toast({
+                title: 'Song Added',
+                description: `Added ${name} to your stitch!`,
+                status: 'success',
+                duration: 3000,
+                isClosable: true,
+            })
         } catch (error) {
             toast({
                 title: "Error",
@@ -157,7 +174,7 @@ function Create() {
         const currentTime = Date.now();
         if (currentTime < nextAllowedRequestTime) {
             toast({
-                description: "Please wait 15 seconds before requesting recommendations again.",
+                description: "Please wait 10 seconds before requesting recommendations again.",
                 status: "error",
                 duration: 3000,
                 isClosable: true,
@@ -170,7 +187,7 @@ function Create() {
             const response = await fetch(`${import.meta.env.VITE_BACKEND_ADDRESS}/recommendation/${stitchId}`);
             const recommendedSongs = await response.json();
             setRecommendedSongs(recommendedSongs);
-            setNextAllowedRequestTime(currentTime + 15000);
+            setNextAllowedRequestTime(currentTime + 10000);
         } catch (error) {
             toast({
                 title: "Error",
@@ -238,6 +255,14 @@ function Create() {
     };
 
     const finalizeStitch = () => {
+        toast.closeAll()
+        toast({
+            title: 'Stitch Finalized',
+            description: `Stitch was saved to your library! Press 'Export to Spotify' on your stitch to update it or add it to Spotify!`,
+            status: 'success',
+            duration: 5000,
+            isClosable: true,
+        })
         navigate(`/${username}`);
     };
 
@@ -315,6 +340,15 @@ function Create() {
                     throw new Error('Failed to delete song');
                 }
 
+                toast.closeAll()
+                toast({
+                    title: 'Song Deleted',
+                    description: `Removed song from your stitch!`,
+                    status: 'success',
+                    duration: 3000,
+                    isClosable: true,
+                })
+
                 setDeleteId('');
                 getStitchSongs();
             } catch (error) {
@@ -337,174 +371,178 @@ function Create() {
         }
     }, [deleteId, stitchId, toast]);
 
+    useEffect(() => {
+        setRecommendedSongs([]);
+    }, [stitchId]);
+
     return (
         <Box className='Create'>
-            <header>
-                <Box bgGradient="radial-gradient(circle, rgba(115, 41, 123, 1) 0%, rgba(0,0,0,1) 86%)">
-                    <Navbar username={username} page={"create"} />
-                </Box>
-            </header>
-            <main>
-                <PreferenceModal
-                    isOpen={isCreateOpen}
-                    onClose={handlePreferenceModalClose}
-                    moodValue={moodValue}
-                    setMoodValue={setMoodValue}
-                    danceValue={danceValue}
-                    setDanceValue={setDanceValue}
-                    mixValue={mixValue}
-                    setMixValue={setMixValue}
-                    exploreValue={exploreValue}
-                    setExploreValue={setExploreValue}
-                    handlePreferenceSubmit={handlePreferenceSubmit}
-                    labelStyles={labelStyles}
-                />
-
-                <Box width="100%" display="flex" justifyContent="space-evenly" my='1em'>
-                    <Box className="stitchSection" color="white" minHeight="100vh" flex="1">
-                        <Box px='2em' width='50em'>
-                            <CustomName stitchId={stitchId} />
-                        </Box>
-                        <Flex direction="row" justifyContent="left" mt="1em" gap="0.5em" pl="2em">
-                            <Button
-                                bg="rgb(225, 225, 225)"
-                                color="black"
-                                size="sm"
-                                _focus={{ boxShadow: 'none' }}
-                                _active={{ boxShadow: 'none' }}
-                                _hover={{
-                                    boxShadow: '0 0 20px -2px rgba(255, 255, 255, 0.9)',
-                                    transform: 'translate3d(0, -0.5px, 0) scale(1.01)',
-                                }}
-                                onClick={onCreateOpen}
-                            >
-                                Preferences
-                            </Button>
-                            <Button
-                                bgGradient="linear(to-r, rgba(115, 41, 123, 0.9), rgb(83, 41, 140, 0.9))"
-                                color="white"
-                                size="sm"
-                                _focus={{ boxShadow: 'none' }}
-                                _active={{ boxShadow: 'none' }}
-                                _hover={{
-                                    opacity: 1,
-                                    backgroundSize: 'auto',
-                                    boxShadow: '0 0 20px -2px rgba(195, 111, 199, .5)',
-                                    transform: 'translate3d(0, -0.5px, 0) scale(1.01)',
-                                }}
-                                onClick={handleToVisualization}
-                            >
-                                View Visualization
-                            </Button>
-                            <Button
-                                bgGradient="linear(to-r, rgba(115, 41, 123, 0.9), rgb(83, 41, 140, 0.9))"
-                                color="white"
-                                size="sm"
-                                _focus={{ boxShadow: 'none', bg: 'white', color: 'black' }}
-                                _active={{ boxShadow: 'none' }}
-                                _hover={{
-                                    opacity: 1,
-                                    backgroundSize: 'auto',
-                                    boxShadow: '0 0 20px -2px rgba(195, 111, 199, .5)',
-                                    transform: 'translate3d(0, -0.5px, 0) scale(1.01)',
-                                }}
-                                onClick={finalizeStitch}
-                            >
-                                Finalize Stitch
-                            </Button>
-                        </Flex>
-                        <Box mt="1em" px="2em">
-                            {currentStitchSongs.map((song) => (
-                                <Flex justifyContent="center">
-                                    <Song
-                                        key={song.id}
-                                        track={song}
-                                        onPlay={handleAudioPlay}
-                                        location="currentStitch"
-                                        onRemove={() => handleRemove(song.id)}
-                                    />
-                                </Flex>
-                            ))}
-                        </Box>
+            <Box flex='1'>
+                <header>
+                    <Box bgGradient="radial-gradient(circle, rgba(115, 41, 123, 1) 0%, rgba(0,0,0,1) 86%)">
+                        <Navbar username={username} page={action} stitchId={stitchId} />
                     </Box>
-                    <Center>
-                        <Divider orientation='vertical' />
-                    </Center>
-                    <Box className="searchSection" color="white" minHeight="100vh" flex="1">
-                        <Flex direction="row" justifyContent="space-between" alignItems="center" gap="1em" px="2em">
-                            <Box textAlign="center" mb='1em' flex='1'>
-                                <FormControl mt="1em">
-                                    <Input
-                                        type='text'
-                                        onChange={handleSearch}
-                                        placeholder='Search for songs here...'
-                                        focusBorderColor='rgb(83, 41, 140)'
-                                    />
-                                </FormControl>
+                </header>
+                <main>
+                    <PreferenceModal
+                        isOpen={isCreateOpen}
+                        onClose={handlePreferenceModalClose}
+                        moodValue={moodValue}
+                        setMoodValue={setMoodValue}
+                        danceValue={danceValue}
+                        setDanceValue={setDanceValue}
+                        mixValue={mixValue}
+                        setMixValue={setMixValue}
+                        exploreValue={exploreValue}
+                        setExploreValue={setExploreValue}
+                        handlePreferenceSubmit={handlePreferenceSubmit}
+                        labelStyles={labelStyles}
+                    />
+
+                    <Box width="100%" display="flex" justifyContent="space-evenly" my='1em' height='90vh'>
+                        <Box className="stitchSection" color="white" flex="1">
+                            <Box px='2em' width='53em'>
+                                <CustomName stitchId={stitchId} />
                             </Box>
-                            <Button
-                                bgGradient="linear(to-r, rgba(115, 41, 123, 0.9), rgb(83, 41, 140, 0.9))"
-                                color="white"
-                                size="sm"
-                                _focus={{ boxShadow: 'none' }}
-                                _active={{ boxShadow: 'none' }}
-                                _hover={{
-                                    opacity: 1,
-                                    backgroundSize: 'auto',
-                                    boxShadow: '0 0 20px -2px rgba(195, 111, 199, .5)',
-                                    transform: 'translate3d(0, -0.5px, 0) scale(1.01)',
-                                }}
-                                onClick={getRecommendedSongs}
-                            >
-                                Get Recommendations
-                            </Button>
-                        </Flex>
-                        <Box px='2em'>
-                            {searchOptions.slice(0, 3).map((track) => (
-                                <Flex justifyContent="center">
-                                    <Song
-                                        key={track.id}
-                                        track={track}
-                                        onPlay={handleAudioPlay}
-                                        location="addSongs"
-                                        onAdd={() => handleAddSong(track)}
-                                    />
-                                </Flex>
-                            ))}
+                            <Flex direction="row" justifyContent="left" mt="1em" gap="0.5em" pl="2em">
+                                <Button
+                                    bg="rgb(225, 225, 225)"
+                                    color="black"
+                                    size="sm"
+                                    _focus={{ boxShadow: 'none' }}
+                                    _active={{ boxShadow: 'none' }}
+                                    _hover={{
+                                        boxShadow: '0 0 20px -2px rgba(255, 255, 255, 0.9)',
+                                        transform: 'translate3d(0, -0.5px, 0) scale(1.01)',
+                                    }}
+                                    onClick={onCreateOpen}
+                                >
+                                    Preferences
+                                </Button>
+                                <Button
+                                    bgGradient="linear(to-r, rgba(115, 41, 123, 0.9), rgb(83, 41, 140, 0.9))"
+                                    color="white"
+                                    size="sm"
+                                    _focus={{ boxShadow: 'none' }}
+                                    _active={{ boxShadow: 'none' }}
+                                    _hover={{
+                                        opacity: 1,
+                                        backgroundSize: 'auto',
+                                        boxShadow: '0 0 20px -2px rgba(195, 111, 199, .5)',
+                                        transform: 'translate3d(0, -0.5px, 0) scale(1.01)',
+                                    }}
+                                    onClick={handleToVisualization}
+                                >
+                                    View Visualization
+                                </Button>
+                                <Button
+                                    bgGradient="linear(to-r, rgba(115, 41, 123, 0.9), rgb(83, 41, 140, 0.9))"
+                                    color="white"
+                                    size="sm"
+                                    _focus={{ boxShadow: 'none', bg: 'white', color: 'black' }}
+                                    _active={{ boxShadow: 'none' }}
+                                    _hover={{
+                                        opacity: 1,
+                                        backgroundSize: 'auto',
+                                        boxShadow: '0 0 20px -2px rgba(195, 111, 199, .5)',
+                                        transform: 'translate3d(0, -0.5px, 0) scale(1.01)',
+                                    }}
+                                    onClick={finalizeStitch}
+                                >
+                                    Finalize Stitch
+                                </Button>
+                            </Flex>
+                            <Box mt="1em" px="2em" overflowY="auto" maxH="67vh" onMouseEnter={handleMouseEnter} onMouseLeave={handleMouseLeave}>
+                                {currentStitchSongs.map((song, index) => (
+                                    <Flex justifyContent="center" key={index}>
+                                        <Song
+                                            key={song.id}
+                                            track={song}
+                                            onPlay={handleAudioPlay}
+                                            location="currentStitch"
+                                            onRemove={() => handleRemove(song.id)}
+                                        />
+                                    </Flex>
+                                ))}
+                            </Box>
                         </Box>
+                        <Center>
+                            <Divider orientation='vertical' />
+                        </Center>
+                        <Box className="searchSection" color="white" minHeight="100vh" flex="1">
+                            <Flex direction="row" justifyContent="space-between" alignItems="center" gap="1em" px="2em">
+                                <Box textAlign="center" mb='1em' flex='1'>
+                                    <FormControl mt="1em">
+                                        <Input
+                                            type='text'
+                                            onChange={handleSearch}
+                                            placeholder='Search for songs here...'
+                                            focusBorderColor='rgb(83, 41, 140)'
+                                        />
+                                    </FormControl>
+                                </Box>
+                                <Button
+                                    bgGradient="linear(to-r, rgba(115, 41, 123, 0.9), rgb(83, 41, 140, 0.9))"
+                                    color="white"
+                                    size="sm"
+                                    _focus={{ boxShadow: 'none' }}
+                                    _active={{ boxShadow: 'none' }}
+                                    _hover={{
+                                        opacity: 1,
+                                        backgroundSize: 'auto',
+                                        boxShadow: '0 0 20px -2px rgba(195, 111, 199, .5)',
+                                        transform: 'translate3d(0, -0.5px, 0) scale(1.01)',
+                                    }}
+                                    onClick={getRecommendedSongs}
+                                >
+                                    Get Recommendations
+                                </Button>
+                            </Flex>
+                            <Box px='2em'>
+                                {searchOptions.slice(0, 3).map((track, index) => (
+                                    <Flex justifyContent="center" key={index}>
+                                        <Song
+                                            track={track}
+                                            onPlay={handleAudioPlay}
+                                            location="addSongs"
+                                            onAdd={() => handleAddSong(track)}
+                                        />
+                                    </Flex>
+                                ))}
+                            </Box>
 
-                        <Box px='2em' mt='1em'>
-                            {loadingRecommended ? (
-                                <>
-                                    <Text mb='1em' fontWeight='bold'>Recommended Songs</Text>
-                                    <Center>
-                                        <Spinner size='xl' color='rgb(83, 41, 140)' emptyColor='gray.200' />
-                                    </Center>
-                                </>
-                            ) : (
-                                <>
-                                    {recommendedSongs.length > 0 && (
-                                        <>
-                                            <Text mb='1em' fontWeight='bold'>Recommended Songs</Text>
-                                            {recommendedSongs.slice(0, 5).map((track) => (
-                                                <Flex justifyContent="center">
-                                                    <Song
-                                                        key={track.id}
-                                                        track={track}
-                                                        onPlay={handleAudioPlay}
-                                                        location="addSongs"
-                                                        onAdd={() => handleAddSong(track)}
-                                                    />
-                                                </Flex>
-                                            ))}
-                                        </>
-                                    )}
-                                </>
-                            )}
+                            <Box px='2em' mt='1em'>
+                                {loadingRecommended ? (
+                                    <>
+                                        <Text mb='1em' fontWeight='bold'>Recommended Songs</Text>
+                                        <Center>
+                                            <Spinner size='xl' color='rgb(83, 41, 140)' emptyColor='gray.200' />
+                                        </Center>
+                                    </>
+                                ) : (
+                                    <>
+                                        {recommendedSongs.length > 0 && (
+                                            <>
+                                                <Text mb='1em' fontWeight='bold'>Recommended Songs</Text>
+                                                {recommendedSongs.slice(0, 5).map((track) => (
+                                                    <Flex justifyContent="center" key={track.id}>
+                                                        <Song
+                                                            track={track}
+                                                            onPlay={handleAudioPlay}
+                                                            location="addSongs"
+                                                            onAdd={() => handleAddSong(track)}
+                                                        />
+                                                    </Flex>
+                                                ))}
+                                            </>
+                                        )}
+                                    </>
+                                )}
+                            </Box>
                         </Box>
                     </Box>
-                </Box>
-            </main>
+                </main>
+            </Box>
             <footer>
                 <Footer />
             </footer>

--- a/front-end/src/Create.jsx
+++ b/front-end/src/Create.jsx
@@ -73,6 +73,7 @@ function Create() {
             }
             setSearchOptions(searchData.tracks.items);
         } catch (error) {
+            toast.closeAll()
             toast({
                 title: "Error",
                 description: error.message,
@@ -103,6 +104,7 @@ function Create() {
                 body: JSON.stringify({ stitchId, imageUrl })
             });
         } catch (error) {
+            toast.closeAll()
             toast({
                 title: "Error",
                 description: "Error updating stitch image",
@@ -147,6 +149,7 @@ function Create() {
                 isClosable: true,
             })
         } catch (error) {
+            toast.closeAll()
             toast({
                 title: "Error",
                 description: "Error adding song to stitch",
@@ -161,6 +164,7 @@ function Create() {
     const getRecommendedSongs = async () => {
         await getStitchSongs();
         if (currentStitchSongs.length == 0) {
+            toast.closeAll()
             toast({
                 description: "Please add your first song to receive recommendations!",
                 status: "info",
@@ -173,6 +177,7 @@ function Create() {
 
         const currentTime = Date.now();
         if (currentTime < nextAllowedRequestTime) {
+            toast.closeAll()
             toast({
                 description: "Please wait 10 seconds before requesting recommendations again.",
                 status: "error",
@@ -189,6 +194,7 @@ function Create() {
             setRecommendedSongs(recommendedSongs);
             setNextAllowedRequestTime(currentTime + 10000);
         } catch (error) {
+            toast.closeAll()
             toast({
                 title: "Error",
                 description: "Error getting recommendations.",
@@ -215,6 +221,7 @@ function Create() {
             setMixValue(preferences.mix);
             setExploreValue(preferences.explore);
         } catch (error) {
+            toast.closeAll()
             toast({
                 title: "Error",
                 description: "Error getting stitch preferences.",
@@ -238,6 +245,7 @@ function Create() {
             }
             setCurrentStitchSongs(stitchSongs);
         } catch (error) {
+            toast.closeAll()
             toast({
                 title: "Error",
                 description: "Error getting songs in stitch",
@@ -269,6 +277,7 @@ function Create() {
     const handleToVisualization = async () => {
         await getStitchSongs();
         if (currentStitchSongs.length <= 3) {
+            toast.closeAll()
             toast({
                 description: "Please have at least 4 songs in your stitch before seeing visualization!",
                 status: "info",
@@ -309,6 +318,7 @@ function Create() {
             mixValueRef.current = mixValue;
             exploreValueRef.current = exploreValue;
 
+            toast.closeAll()
             toast({
                 title: "Success",
                 description: "Preferences were saved!",
@@ -318,6 +328,7 @@ function Create() {
                 position: "bottom"
             });
         } catch (error) {
+            toast.closeAll()
             toast({
                 title: "Error",
                 description: "Error updating stitch preferences",
@@ -352,6 +363,7 @@ function Create() {
                 setDeleteId('');
                 getStitchSongs();
             } catch (error) {
+                toast.closeAll()
                 toast({
                     title: "Error",
                     description: error.message,

--- a/front-end/src/CustomName.jsx
+++ b/front-end/src/CustomName.jsx
@@ -31,6 +31,7 @@ const CustomName = ({ stitchId }) => {
                 throw new Error('Failed to update stitch name');
             }
         } catch (error) {
+            toast.closeAll()
             toast({
                 title: "Error",
                 description: error.message,
@@ -55,6 +56,7 @@ const CustomName = ({ stitchId }) => {
                 const data = await response.json();
                 setTitle(data.title || 'Untitled');
             } catch (error) {
+                toast.closeAll()
                 toast({
                     title: "Error",
                     description: `Error fetching stitch name: ${error.message}`,

--- a/front-end/src/CustomName.jsx
+++ b/front-end/src/CustomName.jsx
@@ -74,7 +74,7 @@ const CustomName = ({ stitchId }) => {
             <Editable
                 textAlign='left'
                 fontSize='6xl'
-                fontWeight='bold'
+                // fontWeight='bold'
                 color='white'
                 value={title}
                 onChange={(nextValue) => setTitle(nextValue)}

--- a/front-end/src/Footer.jsx
+++ b/front-end/src/Footer.jsx
@@ -3,8 +3,7 @@ import { Box, Text } from '@chakra-ui/react';
 function Footer() {
     return (
         <Box padding='2em' textAlign='center' alignItems='center' bg='black'>
-            <Text>Diego Landaeta Torres</Text>
-            <Text mt='1em'>Meta University Summer 2024</Text>
+            <Text>Diego Landaeta Torres | Meta University 2024</Text>
         </Box>
     )
 }

--- a/front-end/src/Home.jsx
+++ b/front-end/src/Home.jsx
@@ -22,6 +22,7 @@ function Home() {
             const data = await response.json();
             setStitches(data);
         } catch (error) {
+            toast.closeAll()
             toast({
                 title: "Error",
                 description: "Error loading your stitches.",
@@ -52,6 +53,7 @@ function Home() {
                 setDeleteId('');
                 getStitches();
             } catch (error) {
+                toast.closeAll()
                 toast({
                     title: "Error",
                     description: error.message,

--- a/front-end/src/Navbar.jsx
+++ b/front-end/src/Navbar.jsx
@@ -52,6 +52,7 @@ function Navbar({ username, page, stitchId }) {
     const fetchProfileData = async () => {
         const accessToken = localStorage.getItem('accessToken');
         if (!accessToken) {
+            toast.closeAll()
             toast({
                 title: "Error",
                 description: "No access token: please logout and log back in!",
@@ -76,6 +77,7 @@ function Navbar({ username, page, stitchId }) {
             const data = await response.json();
             setProfileData(data);
         } catch (error) {
+            toast.closeAll()
             toast({
                 title: "Error",
                 description: error.message,
@@ -91,6 +93,7 @@ function Navbar({ username, page, stitchId }) {
     const fetchTopUserTracks = async () => {
         const accessToken = localStorage.getItem('accessToken');
         if (!accessToken) {
+            toast.closeAll()
             toast({
                 title: "Error",
                 description: "No access token: please logout and log back in!",
@@ -115,6 +118,7 @@ function Navbar({ username, page, stitchId }) {
             const data = await response.json();
             setUserTopTracks(data.items);
         } catch (error) {
+            toast.closeAll()
             toast({
                 title: "Error",
                 description: error.message,
@@ -158,6 +162,7 @@ function Navbar({ username, page, stitchId }) {
                 throw new Error('Failed to delete stitch');
             }
         } catch (error) {
+            toast.closeAll()
             toast({
                 title: "Error",
                 description: error.message,
@@ -223,6 +228,7 @@ function Navbar({ username, page, stitchId }) {
             const data = await response.json();
             return data.id;
         } catch (error) {
+            toast.closeAll()
             toast({
                 title: "Error",
                 description: `Error creating new stitch: ${error.message}`,

--- a/front-end/src/SpotifyCallback.jsx
+++ b/front-end/src/SpotifyCallback.jsx
@@ -32,6 +32,7 @@ function SpotifyCallback() {
             localStorage.setItem('accessToken', data.accessToken)
             createUser();
         } catch (error) {
+            toast.closeAll()
             toast({
                 title: "Error",
                 description: error.message,
@@ -78,6 +79,7 @@ function SpotifyCallback() {
     
                 navigate(`/${username}`);
             } catch (error) {
+                toast.closeAll()
                 toast({
                     title: "Error",
                     description: error.message,
@@ -92,6 +94,7 @@ function SpotifyCallback() {
                 }, 3000);
             }
         } else {
+            toast.closeAll()
             toast({
                 title: "Error",
                 description: "No access token found",

--- a/front-end/src/Stitch.jsx
+++ b/front-end/src/Stitch.jsx
@@ -9,7 +9,7 @@ function Stitch({ stitch, username, deleteStitch }) {
     const toast = useToast();
 
     const handleEdit = (stitchId) => () => {
-        navigate(`/${username}/create`, { state: { stitchId } });
+        navigate(`/${username}/edit`, { state: { stitchId } });
     };
 
     const handleShareToSpotify = () => (event) => {

--- a/front-end/src/Stitch.jsx
+++ b/front-end/src/Stitch.jsx
@@ -32,7 +32,7 @@ function Stitch({ stitch, username, deleteStitch }) {
             if (!response.ok) {
                 throw new Error(responseData.error || 'Unknown error');
             }
-    
+            toast.closeAll()
             toast({
                 title: "Success",
                 description: responseData.message,
@@ -43,6 +43,7 @@ function Stitch({ stitch, username, deleteStitch }) {
             });
     
         } catch (error) {
+            toast.closeAll()
             toast({
                 title: "Error",
                 description: "Failed to export stitch to Spotify",

--- a/front-end/src/main.jsx
+++ b/front-end/src/main.jsx
@@ -3,17 +3,27 @@ import ReactDOM from 'react-dom/client'
 import { ChakraProvider, extendTheme } from '@chakra-ui/react'
 import App from './App.jsx'
 import './index.css'
+import CustomName from './CustomName.jsx'
 
 const theme = extendTheme({
   styles: {
     global: {
       body: {
-        bg: "#242424", 
+        bg: "#242424",
         color: "white",
-        fontFamily: "Arial, sans-serif",
+        fontFamily: "Raleway, sans-serif",
+        fontWeight: "500"
       }
     },
   },
+  components: {
+    Heading: {
+      baseStyle: {
+        fontFamily: "Raleway, sans-serif",
+        fontWeight: "600"
+      }
+    }
+  }
 });
 
 ReactDOM.createRoot(document.getElementById('root')).render(

--- a/front-end/src/visualization/Node.jsx
+++ b/front-end/src/visualization/Node.jsx
@@ -25,18 +25,30 @@ const Node = ({ node }) => {
         }
     };
 
-    const textStyle = {
+    const clusterTextStyle = {
         color: "white",
         fontSize: "xs",
         mt: "0.5em",
         textAlign: "center",
         textShadow: "1px 1px 2px rgba(0, 0, 0, 0.8)",
-        width: "100%"
+        width: "100%",
+    };
+
+    const songTextStyle = {
+        color: "white",
+        fontSize: "xs",
+        mt: "0.5em",
+        textAlign: "center",
+        textShadow: "1px 1px 2px rgba(0, 0, 0, 0.8)",
+        width: "100%",
+        whiteSpace: "nowrap",
+        overflow: "hidden",
+        textOverflow: "ellipsis"
     };
 
     const content = isCluster ? (
         <Tooltip label={node.tooltip} hasArrow>
-            <Text {...textStyle}>
+            <Text {...clusterTextStyle}>
                 {node.label}
             </Text>
         </Tooltip>
@@ -48,7 +60,7 @@ const Node = ({ node }) => {
                 boxSize="100%"
                 objectFit="cover"
             />
-            <Text {...textStyle}>
+            <Text {...songTextStyle}>
                 {node.label}
             </Text>
         </Box>

--- a/front-end/src/visualization/Visualization.jsx
+++ b/front-end/src/visualization/Visualization.jsx
@@ -233,7 +233,7 @@ function Visualization() {
     }, [clusterData]);
 
     const handleNavigateToStitch = () => {
-        navigate(`/${username}/create`, { state: { stitchId } });
+        navigate(`/${username}/edit`, { state: { stitchId } });
     }
 
     useEffect(() => {

--- a/front-end/src/visualization/Visualization.jsx
+++ b/front-end/src/visualization/Visualization.jsx
@@ -267,7 +267,7 @@ function Visualization() {
         alignItems: 'center',
         justifyContent: 'center',
         width: "100vw",
-        height: "120vh",
+        height: "110vh",
         position: "relative",
         overflow: "hidden",
         cursor: isDragging ? 'grabbing' : 'grab'
@@ -281,10 +281,10 @@ function Visualization() {
                     <Flex justifyContent="center">
                         <Heading size='2xl'>{title}</Heading>
                     </Flex>
-                    <Flex justifyContent='center' mt='1em'>
-                        <Text color='white' fontSize='md' mt='1.5em' textAlign='center' width='80%'>According to Spotify, a value on valence that's closer to 1.0 will describe happy, cheerful or euphoric songs, while a value closer to 0.0 will relate sad, depressed or angry songs. This visualization clusters songs with their closest valence neighbors!</Text>
+                    <Flex justifyContent='center'>
+                        <Text color='white' fontSize='md' mt='1em' textAlign='center' width='80%'>According to Spotify, a value on valence that's closer to 1.0 will describe happy, cheerful or euphoric songs, while a value closer to 0.0 will relate sad, depressed or angry songs. This visualization clusters songs with their closest valence neighbors!</Text>
                     </Flex>
-                    <Flex justifyContent="center" mt='1em'>
+                    <Flex justifyContent="center">
                         <Button
                             className="navigateToVisualization"
                             bg="white"
@@ -302,7 +302,7 @@ function Visualization() {
                             <Text fontSize="lg">Back to Stitch</Text>
                         </Button>
                     </Flex>
-                    <Flex justifyContent="center" mt="1em">
+                    <Flex justifyContent="center">
                         <Button onClick={zoomIn} m={2} colorScheme="white">Zoom In</Button>
                         <Button onClick={zoomOut} m={2} colorScheme="white">Zoom Out</Button>
                         <Button onClick={resetZoomAndTranslation} m={2} colorScheme="white">Reset</Button>

--- a/front-end/src/visualization/Visualization.jsx
+++ b/front-end/src/visualization/Visualization.jsx
@@ -188,6 +188,7 @@ function Visualization() {
                 const data = await response.json();
                 setClusterData(data);
             } catch (error) {
+                toast.closeAll()
                 toast({
                     title: "Error",
                     description: "Failed to load cluster data.",
@@ -209,6 +210,7 @@ function Visualization() {
                 const data = await response.json();
                 setTitle(data.title || 'Untitled');
             } catch (error) {
+                toast.closeAll()
                 toast({
                     title: "Error",
                     description: "Failed to get stitch name.",


### PR DESCRIPTION
**UX Improvements**

- New font for a more fun interactive look. 
- Added scrolling functionality for the user's stitch songs section. 
- Added checks to make sure that when the user is hovering over their stitch's songs they can only scroll on the stitch and the whole page doesn't move when they reach the end of the list. 
- Decreased spacing of the top part of visualization so user can see more clusters on entry. 
- Added toasts to show that songs were added/deleted successfully as well as a toast for when a stitch is finalized describing how to user can export their stitches.
- Close all toasts before displaying a new toast to make sure that the user doesn't have multiple toasts stacked on top of one another if they perform a lot of actions at once.

**Scrolling functionality for longer stitches**

- Whole screen does not start scrolling once I finish the list of songs do to hover check.

https://github.com/user-attachments/assets/291e618a-79ae-4e11-9292-785df5787681

**New Visualization spacing**

<img width="1728" alt="Screenshot 2024-08-02 at 10 33 13 AM" src="https://github.com/user-attachments/assets/ae597b4e-1ad8-41a5-8ca3-aed0abadabf0">

**New add and remove from stitch toasts**

<img width="1728" alt="Screenshot 2024-08-02 at 11 21 01 AM" src="https://github.com/user-attachments/assets/b00c8f2a-dc7f-4329-ade6-c98600dad0ae">
<img width="1728" alt="Screenshot 2024-08-02 at 11 21 16 AM" src="https://github.com/user-attachments/assets/75186f21-efdb-4e1e-8b45-6b6e6469180b">

**New stitch finalized toast**

<img width="1728" alt="Screenshot 2024-08-02 at 11 21 32 AM" src="https://github.com/user-attachments/assets/abe67b7a-bb60-4ea2-9797-6755bdc4e106">

**Example of why I cancel all toasts before making a new one**

https://github.com/user-attachments/assets/8c0267be-55a9-478b-84ae-e1850084f18b

**Draft State Stretch Goal**
- When the user first creates a stitch where if they navigate out of the create page before clicking finalize stitch, the stitch is deleted. 
- Created new navigation "edit" to differentiate when the Create component is being used for a new stitch versus editing an existing stitch.
- Once the user clicks visualization, the stitch is then treated as editable when going back.

**Warning modal that appears to create "draft" state**

<img width="1728" alt="Screenshot 2024-08-02 at 11 54 16 AM" src="https://github.com/user-attachments/assets/66e69698-08c8-4942-af6f-c0845d682368">
